### PR TITLE
Enable strict PHP types for translation wizard

### DIFF
--- a/systems/translationwizard/translationwizard.php
+++ b/systems/translationwizard/translationwizard.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 //For versioninfos just take a look at /modules/translationwizard/versions.txt
 
 // Okay, someone wants to use this outside of normal game flow.. no real harm
@@ -34,7 +35,7 @@ function translationwizard_getmoduleinfo(){
 		),
 		"prefs"=>array(
 		    "Translation Wizard - User prefs,title",
-				"language"=>"Languages for the Wizard,enum,".getsetting("serverlanguages","en,English,fr,Français,dk,Danish,de,Deutsch,es,Español,it,Italian"),
+				"language"=>"Languages for the Wizard,enum,".getsetting("serverlanguages","en,English,fr,FranÃ§ais,dk,Danish,de,Deutsch,es,EspaÃ±ol,it,Italian"),
 				"Note: don't change this if you don't need to... it is set up in the Translation Wizard!,note",
 				"allowed"=>"Does this user have unrestricted access to the wizard?,bool|0",
 				"Note: This is only active if the restriction settings is 'true' in the module settings,note",

--- a/systems/translationwizard/translationwizard/build_nav.php
+++ b/systems/translationwizard/translationwizard/build_nav.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 	addnav(array("`bSwitch to %s view`b",translate_inline($viewsimple?"simple":"advanced")),"runmodule.php?module=translationwizard&op=switchview&from=".rawurlencode("module=translationwizard&op=$op&mode=$mode"));
 	addnav("Operations");

--- a/systems/translationwizard/translationwizard/changescheme.php
+++ b/systems/translationwizard/translationwizard/changescheme.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 if (httppost('save'))
 	{
@@ -11,7 +12,7 @@ if (httppost('save'))
 	{
 	$settings= array(
 		"Scheme Settings for the Wizard,title",
-		"language"=>"What schema do you want to translate for?,enum,".getsetting("serverlanguages","en,English,de,Deutsch,fr,FranÁais,dk,Danish,es,EspaÒol,it,Italian"),
+		"language"=>"What schema do you want to translate for?,enum,".getsetting("serverlanguages","en,English,de,Deutsch,fr,Fran√ßais,dk,Danish,es,Espa√±ol,it,Italian"),
 		"Server supported languages only (view your game settings or before 1.1.1 prefs.php or configuration.php),note"
 	);
 	$lang=get_module_pref("language");

--- a/systems/translationwizard/translationwizard/check.php
+++ b/systems/translationwizard/translationwizard/check.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if (httppost("listing")) $mode="listing";
 if (httppost("deleteall")) $mode="deleteall";
 switch ($mode)

--- a/systems/translationwizard/translationwizard/copychecked.php
+++ b/systems/translationwizard/translationwizard/copychecked.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 foreach($transintext as $key=>$trans)
 	{
 	$intext = addslashes(rawurldecode($transintext[$key]));  //addslashes because  this comes in encoded and only plain text ... it's from the checkboxes directly

--- a/systems/translationwizard/translationwizard/default.php
+++ b/systems/translationwizard/translationwizard/default.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $sql = "SELECT count(*) AS count FROM " . db_prefix("untranslated");
 $count = db_fetch_assoc(db_query($sql));
 if ($count['count'] > 0) {

--- a/systems/translationwizard/translationwizard/deletechecked.php
+++ b/systems/translationwizard/translationwizard/deletechecked.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 foreach($transintext as $key=>$trans) {
 	if ($transintext[$key]<>"")
 		{

--- a/systems/translationwizard/translationwizard/deleteempty.php
+++ b/systems/translationwizard/translationwizard/deleteempty.php
@@ -1,4 +1,5 @@
-<?php	
+<?php
+declare(strict_types=1);	
 if (httppost("listing")) $mode="listing";
 if (httppost("deleteall")) $mode="delete";
 switch ($mode)

--- a/systems/translationwizard/translationwizard/deleteuninstalled.php
+++ b/systems/translationwizard/translationwizard/deleteuninstalled.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $what=httpget('deletemode');
 switch ($what) {
 

--- a/systems/translationwizard/translationwizard/edit_single.php
+++ b/systems/translationwizard/translationwizard/edit_single.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 if ($from=="") $from="module=translationwizard&op=list";
 rawoutput("<form action='runmodule.php?".$from."&mode=save&from=".rawurlencode($from)."' method='post'>");
 addnav("", "runmodule.php?".$from."&mode=save&from=".rawurlencode($from));

--- a/systems/translationwizard/translationwizard/editchecked.php
+++ b/systems/translationwizard/translationwizard/editchecked.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 rawoutput("<br>");
 output("`n`bBeware of the autologoff-timeout!`b`n`n");

--- a/systems/translationwizard/translationwizard/errorhandler.php
+++ b/systems/translationwizard/translationwizard/errorhandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 switch (httpget('error'))
 	{		
 	case 1:

--- a/systems/translationwizard/translationwizard/fix.php
+++ b/systems/translationwizard/translationwizard/fix.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 switch ($mode) 
 {
 	case "fix": //remove already translated from the untranslated table (in an extra point because the query takes a few seconds)

--- a/systems/translationwizard/translationwizard/help.php
+++ b/systems/translationwizard/translationwizard/help.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 output("`b`^This is a general help how to use this Wizard.`0`b");
 output_notl("`n`n");
 

--- a/systems/translationwizard/translationwizard/insert_central.php
+++ b/systems/translationwizard/translationwizard/insert_central.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 switch($mode)
 {
 case "continue":

--- a/systems/translationwizard/translationwizard/known.php
+++ b/systems/translationwizard/translationwizard/known.php
@@ -1,4 +1,5 @@
-<?php			
+<?php
+declare(strict_types=1);			
 $central=httpget('central');
 if ($central)
 	{

--- a/systems/translationwizard/translationwizard/list.php
+++ b/systems/translationwizard/translationwizard/list.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 //some kind of header
 if (httppost("deletechecked")) {
 	require("./modules/translationwizard/deletechecked.php"); //if you want to delete the checked translations, this commences the deletion process

--- a/systems/translationwizard/translationwizard/multichecked.php
+++ b/systems/translationwizard/translationwizard/multichecked.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $alrighty=true;
 foreach($transintext as $key=>$trans) {
 	if ($transouttext[$key]<>"")

--- a/systems/translationwizard/translationwizard/overview.php
+++ b/systems/translationwizard/translationwizard/overview.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 output("Overview:");
 output_notl("`n`n");
 $sql= "SELECT count(*) AS counter, uri,language FROM ".db_prefix("translations")." GROUP BY language,uri";

--- a/systems/translationwizard/translationwizard/pull.php
+++ b/systems/translationwizard/translationwizard/pull.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 require_once("lib/pullurl.php");
 $masterpath=get_module_setting('lookuppath')."/";
 //$masterpath="http://pull.strahd.de/homes/root/";

--- a/systems/translationwizard/translationwizard/push.php
+++ b/systems/translationwizard/translationwizard/push.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $datum = getdate(time());
 $currentdate=$datum['mon']."-".$datum['mday']."-".$datum['year'];
 $currenttime=$datum['hours'].":".$datum['minutes'].":".$datum['seconds'];

--- a/systems/translationwizard/translationwizard/randomsave.php
+++ b/systems/translationwizard/translationwizard/randomsave.php
@@ -1,4 +1,5 @@
-<?php	
+<?php
+declare(strict_types=1);	
 $intext = httppost('intext');
 $outtext = httppost('outtext');
 $namespace = httppost('namespace');

--- a/systems/translationwizard/translationwizard/save_single.php
+++ b/systems/translationwizard/translationwizard/save_single.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 $intext = httppost('intext');
 $outtext = httppost('outtext');
 if ($outtext <> "") {

--- a/systems/translationwizard/translationwizard/scanmodules.php
+++ b/systems/translationwizard/translationwizard/scanmodules.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 switch (httpget('error')) {
 	case 1:
 		output("`b`%Insert successful!`b`0");

--- a/systems/translationwizard/translationwizard/scanmodules_func.php
+++ b/systems/translationwizard/translationwizard/scanmodules_func.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 function wizard_scanfile($filepath,$debug=false,$standard_tlschema=false) {
 	// made by the incomparable genius Edorian, master of the realms and destroyer of souls
 	if(!is_file($filepath))

--- a/systems/translationwizard/translationwizard/scanvalidfiles.php
+++ b/systems/translationwizard/translationwizard/scanvalidfiles.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /* This is mostly a copy of the source.php*/
 
 function wizard_showvalidfiles($dosubmit=true,$onlymodules=0,$showselectbox=true,$mainmodulecheck=false) {

--- a/systems/translationwizard/translationwizard/searchandedit.php
+++ b/systems/translationwizard/translationwizard/searchandedit.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 //debug($session['user']['specialmisc']);
 switch ($mode)
 {

--- a/systems/translationwizard/translationwizard/searchandreplace.php
+++ b/systems/translationwizard/translationwizard/searchandreplace.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 //debug($session['user']['specialmisc']);
 switch ($mode)
 {

--- a/systems/translationwizard/translationwizard/showversionlog.php
+++ b/systems/translationwizard/translationwizard/showversionlog.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 require_once("lib/pullurl.php");
 $log=file("modules/translationwizard/versions.txt");
 foreach($log as $val) {

--- a/systems/translationwizard/translationwizard/switchview.php
+++ b/systems/translationwizard/translationwizard/switchview.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 set_module_pref("view",!$viewsimple,"translationwizard");
 redirect("runmodule.php?$from"); //just redirecting to the main to make your choice visible by now
 ?>

--- a/systems/translationwizard/translationwizard/translationwizard_dohook.php
+++ b/systems/translationwizard/translationwizard/translationwizard_dohook.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 switch ($hookname)
 {
 case "superuser":

--- a/systems/translationwizard/translationwizard/translationwizard_getinfo.php
+++ b/systems/translationwizard/translationwizard/translationwizard_getinfo.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 //Slightly modified by JT Traub in the original untranslated.php
 	$info = array(
 	    "name"=>"Translation Wizard",
@@ -22,7 +23,7 @@
 		),
 		"prefs"=>array(
 		    "Translation Wizard - User prefs,title",
-			"language"=>"Languages for the Wizard,enum,en,English,de,Deutsch,pt,Portuguese,dk,Danish,es,Español,it,Italiano,ru,Russian,ee, Estonian(Eesti)",
+			"language"=>"Languages for the Wizard,enum,en,English,de,Deutsch,pt,Portuguese,dk,Danish,es,EspaÃ±ol,it,Italiano,ru,Russian,ee, Estonian(Eesti)",
 			"Note: don't change this if you don't need to... it is set up in the Translation Wizard!,note",
 			"allowed"=>"Does this user have unrestricted access to the wizard?,bool|0",
 			"Note: This is only active if the restriction settings is 'true' in the module settings,note",

--- a/systems/translationwizard/translationwizard/truncate.php
+++ b/systems/translationwizard/translationwizard/truncate.php
@@ -1,4 +1,5 @@
-<?php			
+<?php
+declare(strict_types=1);			
 $central=httpget('central');
 if ($central)
 	{


### PR DESCRIPTION
## Summary
- enforce strict typing on all translation wizard PHP scripts

## Testing
- `php -l modules/systems/translationwizard/translationwizard/*.php`


------
https://chatgpt.com/codex/tasks/task_e_6873b06bdb888329aa2120a177e8c4b1