### PR TITLE
Add documentation and types to TranslationWizard

### DIFF
--- a/systems/translationwizard/translationwizard.php
+++ b/systems/translationwizard/translationwizard.php
@@ -6,7 +6,12 @@ declare(strict_types=1);
 if(!defined('OVERRIDE_FORCED_NAV')) define("OVERRIDE_FORCED_NAV",true);
 require_once("modules/translationwizard/TranslationWizard.php");
 
-function translationwizard_getmoduleinfo(){
+/**
+ * Return module metadata for the Translation Wizard.
+ *
+ * @return array Configuration for the module
+ */
+function translationwizard_getmoduleinfo(): array{
 	//Slightly modified by JT Traub in the original untranslated.php
 	$info = array(
 	    "name"=>"Translation Wizard",
@@ -46,7 +51,12 @@ function translationwizard_getmoduleinfo(){
     return $info;
 }
 
-function translationwizard_install(){
+/**
+ * Install the Translation Wizard module and create required tables.
+ *
+ * @return bool True on success
+ */
+function translationwizard_install(): bool{
 	module_addhook("superuser");
 	module_addhook("header-modules");
 	if (is_module_active("translationwizard")) debug("Module Translationwizard updated");
@@ -67,22 +77,43 @@ function translationwizard_install(){
 	return true;
 }
 
-function translationwizard_uninstall() {
-	debug ("Performing Uninstall on Translation Wizard. Thank you for using!`n`n");
-	if(db_table_exists(db_prefix("temp_translations"))){
-		$result=db_query("DROP TABLE ".db_prefix("temp_translations"));
-	}
-	return $result;
+/**
+ * Remove temporary tables created by the Translation Wizard module.
+ *
+ * @return bool True on success
+ */
+function translationwizard_uninstall(): bool {
+        debug ("Performing Uninstall on Translation Wizard. Thank you for using!`n`n");
+        $result = true;
+        if(db_table_exists(db_prefix("temp_translations"))){
+                $query=db_query("DROP TABLE ".db_prefix("temp_translations"));
+                $result = (bool)$query;
+        }
+        return $result;
 }
 
 
-function translationwizard_dohook($hookname, $args){
-	global $session;
-	require("./modules/translationwizard/translationwizard_dohook.php");
-	return $args;
+/**
+ * Hook dispatcher for the Translation Wizard.
+ *
+ * @param string $hookname Name of the hook
+ * @param array  $args     Arguments passed by the hook system
+ *
+ * @return array Modified arguments
+ */
+function translationwizard_dohook(string $hookname, array $args): array{
+        global $session;
+        require("./modules/translationwizard/translationwizard_dohook.php");
+        return $args;
 }
 
-function translationwizard_run(){
+/**
+ * Main execution dispatcher for the Translation Wizard module.
+ * Handles request routing and page setup.
+ *
+ * @return void
+ */
+function translationwizard_run(): void{
 	global $session,$logd_version,$coding;
 	check_su_access(SU_IS_TRANSLATOR); //check again Superuser Access
 	$op = httpget('op');

--- a/systems/translationwizard/translationwizard/scanmodules_func.php
+++ b/systems/translationwizard/translationwizard/scanmodules_func.php
@@ -1,6 +1,15 @@
 <?php
 declare(strict_types=1);
-function wizard_scanfile($filepath,$debug=false,$standard_tlschema=false) {
+/**
+ * Parse a PHP file and return all translatable strings.
+ *
+ * @param string      $filepath          Absolute file path to scan
+ * @param bool        $debug             Output debug information
+ * @param string|null $standard_tlschema Default translation schema or null to detect
+ *
+ * @return array List of detected texts with schemas
+ */
+function wizard_scanfile(string $filepath, bool $debug=false, ?string $standard_tlschema=null): array {
 	// made by the incomparable genius Edorian, master of the realms and destroyer of souls
 	if(!is_file($filepath))
 	{
@@ -417,7 +426,16 @@ function wizard_scanfile($filepath,$debug=false,$standard_tlschema=false) {
 
 }
 
-function wizard_insertfile($delrows,$languageschema,$serialized=false) {
+/**
+ * Insert untranslated strings into the database.
+ *
+ * @param mixed  $delrows        Array or single row of strings to insert
+ * @param string $languageschema Target language schema
+ * @param bool   $serialized     Whether the rows are serialized
+ *
+ * @return void
+ */
+function wizard_insertfile($delrows, string $languageschema, bool $serialized=false): void {
 	if (is_array($delrows))  //setting for any intexts you might receive
 	{
 		$insertrows = $delrows;
@@ -439,7 +457,16 @@ function wizard_insertfile($delrows,$languageschema,$serialized=false) {
 	}
 }
 
-function wizard_skipcommentary($str,&$i,&$line)
+/**
+ * Skip comments in the parsed string while scanning a file.
+ *
+ * @param string $str  Entire file content
+ * @param int    &$i   Current character index (modified by reference)
+ * @param int    &$line Current line number (modified by reference)
+ *
+ * @return void
+ */
+function wizard_skipcommentary(string $str,int &$i,int &$line): void
 {
 	while($str[$i] == "/" && $str[$i] != "")
 	{
@@ -469,7 +496,16 @@ function wizard_skipcommentary($str,&$i,&$line)
 	}
 }
 
-function already_in_array($array,$text,$schema)
+/**
+ * Check whether a translation entry already exists in an array.
+ *
+ * @param array  $array  Current list of translations
+ * @param string $text   Text being checked
+ * @param string $schema Translation schema of the text
+ *
+ * @return bool True if the entry exists
+ */
+function already_in_array(array $array,string $text,string $schema): bool
 {
 	foreach ($array as $entry) 
 	{

--- a/systems/translationwizard/translationwizard/scanvalidfiles.php
+++ b/systems/translationwizard/translationwizard/scanvalidfiles.php
@@ -2,7 +2,17 @@
 declare(strict_types=1);
 /* This is mostly a copy of the source.php*/
 
-function wizard_showvalidfiles($dosubmit=true,$onlymodules=0,$showselectbox=true,$mainmodulecheck=false) {
+/**
+ * Build a list of files that can be scanned for translations.
+ *
+ * @param bool $dosubmit        Whether to auto submit the form on change
+ * @param int  $onlymodules     Restrict search to modules (1) or submodules (2)
+ * @param bool $showselectbox   Show the select element with files
+ * @param bool $mainmodulecheck Enable javascript module check handler
+ *
+ * @return array List of file names that may be scanned
+ */
+function wizard_showvalidfiles(bool $dosubmit=true,int $onlymodules=0,bool $showselectbox=true,bool $mainmodulecheck=false): array {
 	global $coding;
 	require_once("lib/errorhandling.php");
 	$url="";
@@ -108,7 +118,14 @@ function wizard_showvalidfiles($dosubmit=true,$onlymodules=0,$showselectbox=true
 	return $outputfiles;
 }
 
-function wizard_tree($base) {
+/**
+ * Recursively build a list of directories within a base path.
+ *
+ * @param string $base Directory base path
+ *
+ * @return array Array of directory paths
+ */
+function wizard_tree(string $base): array {
 	$d = dir("$base");
 	$back=array();
 	while($entry = $d->read()) {


### PR DESCRIPTION
## Summary
- document Translation Wizard API functions
- apply scalar type hints and return types

## Testing
- `php -l systems/translationwizard/translationwizard.php`
- `php -l systems/translationwizard/translationwizard/scanmodules_func.php`
- `php -l systems/translationwizard/translationwizard/scanvalidfiles.php`


------
https://chatgpt.com/codex/tasks/task_e_6873be74d97c832999d737973b346ae3