### PR TITLE
Refactor translationwizard forms

### DIFF
--- a/systems/translationwizard/translationwizard.php
+++ b/systems/translationwizard/translationwizard.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 // Okay, someone wants to use this outside of normal game flow.. no real harm
 if(!defined('OVERRIDE_FORCED_NAV')) define("OVERRIDE_FORCED_NAV",true);
 require_once("modules/translationwizard/TranslationWizard.php");
+require_once("modules/translationwizard/form_helpers.php");
 
 /**
  * Return module metadata for the Translation Wizard.

--- a/systems/translationwizard/translationwizard/check.php
+++ b/systems/translationwizard/translationwizard/check.php
@@ -80,9 +80,8 @@ switch ($mode)
 	case "deleteall":
 		$sql= "SELECT count(  tid  )  AS counter, min(tid) as tid, intext, uri,language FROM  ".db_prefix("translations")." GROUP  BY intext, uri, language HAVING counter >1;";
 		$result = db_query($sql);
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=check&mode=delete' method='post'>");
-		addnav("", "runmodule.php?module=translationwizard&op=check&mode=delete");
-		rawoutput("<input type='hidden' name='op' value='check'>");
+                tw_form_open('check&mode=delete', ['op' => 'check']);
+                addnav("", "runmodule.php?module=translationwizard&op=check&mode=delete");
 		output("`n`n %s rows have been found not to be unique within your translations table.`n`n",db_num_rows($result));
 		output("`0This operation will delete one occurrence of each row. `n`n`b`$ CAUTION!`b`0`n`nDue to technical reasons, this operation can't let you select every single line.");
 		output("The query would cost a lot of time and MySql might time out or the query block your game for more than just seconds.");
@@ -93,7 +92,7 @@ switch ($mode)
 		rawoutput("<option label='min' selected>Delete first</option>");
 		rawoutput("<option label='max'>Delete last</option>");
 		rawoutput("</select>");
-		rawoutput("<br><br><br><br>  <input type='submit' value='". translate_inline("Execute") ."' class='button'></form>");
+                tw_form_close(translate_inline('Execute'));
 		output("`b`i`$ Attention, no additional confirmation`i`b`0");
 
 	break;
@@ -101,19 +100,20 @@ switch ($mode)
 	default:  //if the user hits the button just to check for duplicates
 		$sql= "SELECT count(  tid  )  AS counter, min(tid) as tid, intext, uri,language FROM  ".db_prefix("translations")." GROUP  BY intext, uri, language HAVING counter >1;";
 		$result = db_query($sql);
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=check&mode=delete' method='post'>");
-		addnav("", "runmodule.php?module=translationwizard&op=check&mode=delete");
-		rawoutput("<input type='hidden' name='op' value='check'>");
+                tw_form_open('check&mode=delete', ['op' => 'check']);
+                addnav("", "runmodule.php?module=translationwizard&op=check&mode=delete");
 		output("`n`n %s rows have been found not to be unique within your translations table.`n`n",db_num_rows($result));
 		if (db_num_rows($result)==0) //table is fine, no redundant rows
 			{
 			output("Congratulations! Your translation table does not have any redundant entries!");
-			rawoutput("</form");
+                        tw_form_close();
 			break;
 			}
 		output("What do you want to do?`n`n`n`n");
-		rawoutput("<input type='submit' name='deleteall' value='". translate_inline("Delete multiple automatically") ."' class='button'>");
-		rawoutput("<input type='submit' name='listing' value='". translate_inline("Delete manually") ."' class='button'></form>");
+                rawoutput("<input type='submit' name='deleteall' value='". translate_inline("Delete multiple automatically") ."' class='button'>");
+                rawoutput("<input type='submit' name='listing' value='". translate_inline("Delete manually") ."' class='button'>");
+                tw_form_close();
 	break;
 		}
 ?>
+

--- a/systems/translationwizard/translationwizard/default.php
+++ b/systems/translationwizard/translationwizard/default.php
@@ -10,7 +10,11 @@ if ($count['count'] > 0) {
 		$row['intext'] = stripslashes($row['intext']);
 		$submit = translate_inline("Save Translation");
 		$skip = translate_inline("Skip Translation");
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=randomsave' method='post'>");
+                tw_form_open('randomsave', [
+                    'id'        => $row['id'],
+                    'language'  => $row['language'],
+                    'namespace' => $row['namespace'],
+                ]);
 		output("`^`cThere are `&%s`^ untranslated texts in the database.`c`n`n", $count['count']);
 		rawoutput("<table width='80%'>");
 		rawoutput("<tr><td width='30%'>");
@@ -21,14 +25,9 @@ if ($count['count'] > 0) {
 		rawoutput("</td><td></td></tr>");
 		rawoutput("<tr><td width='30%'><textarea cols='35' rows='4' name='intext' readonly>".$row['intext']."</textarea></td>");
 		rawoutput("<td width='30%'><textarea cols='25' rows='4' name='outtext'></textarea></td></tr></table>");
-		rawoutput("<input type='hidden' name='id' value='{$row['id']}'>");
-		rawoutput("<input type='hidden' name='language' value='{$row['language']}'>");
-		rawoutput("<input type='hidden' name='namespace' value='{$row['namespace']}'>");
-		rawoutput("<input type='submit' value='$submit' class='button'>");
-		rawoutput("</form>");
-		rawoutput("<form action='runmodule.php?module=translationwizard' method='post'>");
-		rawoutput("<input type='submit' value='$skip' class='button'>");
-		rawoutput("</form>");
+                tw_form_close($submit);
+                tw_form_open('');
+                tw_form_close($skip);
 		addnav("", "runmodule.php?module=translationwizard&op=randomsave");
 		addnav("", "runmodule.php?module=translationwizard");
 	} else {

--- a/systems/translationwizard/translationwizard/form_helpers.php
+++ b/systems/translationwizard/translationwizard/form_helpers.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Helper functions for Translation Wizard forms.
+ */
+
+function tw_form_open(string $action = '', array $hidden = [], string $method = 'POST'): void
+{
+    $action = htmlspecialchars($action, ENT_COMPAT, getsetting('charset', 'ISO-8859-1'));
+    $url = "runmodule.php?module=translationwizard";
+    if ('' !== $action) {
+        $url .= "&op={$action}";
+    }
+    rawoutput("<form action='{$url}' method='{$method}' class='wizard-form'>");
+    foreach ($hidden as $name => $value) {
+        $name = htmlspecialchars($name, ENT_COMPAT, getsetting('charset', 'ISO-8859-1'));
+        $value = htmlspecialchars((string)$value, ENT_COMPAT, getsetting('charset', 'ISO-8859-1'));
+        rawoutput("<input type='hidden' name='{$name}' value='{$value}'>");
+    }
+}
+
+function tw_form_close(?string $label = null): void
+{
+    if (null !== $label && '' !== $label) {
+        $label = htmlspecialchars($label, ENT_COMPAT, getsetting('charset', 'ISO-8859-1'));
+        rawoutput("<input type='submit' value='{$label}' class='button wizard-button'>");
+    }
+    rawoutput('</form>');
+}
+
+


### PR DESCRIPTION
## Summary
- centralize wizard form markup helpers
- use the new helper in the translation wizard default page
- use the new helper in the duplicate-check workflow

## Testing
- `php -l systems/translationwizard/translationwizard/form_helpers.php`
- `php -l systems/translationwizard/translationwizard/check.php`
- `php -l systems/translationwizard/translationwizard/default.php`
- `php -l systems/translationwizard/translationwizard.php`


------
https://chatgpt.com/codex/tasks/task_e_6873c1abebfc8329ab3a41e0bcaa118e