### PR TITLE
Add WizardService for repeated translation operations

### DIFF
--- a/systems/translationwizard/translationwizard.php
+++ b/systems/translationwizard/translationwizard.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 if(!defined('OVERRIDE_FORCED_NAV')) define("OVERRIDE_FORCED_NAV",true);
 require_once("modules/translationwizard/TranslationWizard.php");
 require_once("modules/translationwizard/form_helpers.php");
+require_once("modules/translationwizard/WizardService.php");
 
 /**
  * Return module metadata for the Translation Wizard.

--- a/systems/translationwizard/translationwizard/WizardService.php
+++ b/systems/translationwizard/translationwizard/WizardService.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+class WizardService {
+    public static function ensureArray($value): array {
+        if (is_array($value)) {
+            return $value;
+        }
+        return ($value !== null && $value !== '') ? array($value) : array();
+    }
+
+    public static function createTranslation(string $language, string $namespace, string $intext, string $outtext, string $author, string $version) {
+        $sql = "INSERT INTO " . db_prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" .
+               " ('$language','$namespace','$intext','$outtext','$author','$version')";
+        return db_query($sql);
+    }
+
+    public static function deleteUntranslated(string $language, string $namespace, string $intext) {
+        $sql = "DELETE FROM " . db_prefix("untranslated") . " WHERE intext = '$intext' AND language = '$language' AND namespace = '$namespace'";
+        return db_query($sql);
+    }
+
+    public static function saveTranslation(string $language, string $namespace, string $intext, string $outtext, string $author, string $version): bool {
+        $insert = self::createTranslation($language, $namespace, $intext, $outtext, $author, $version);
+        $delete = self::deleteUntranslated($language, $namespace, $intext);
+        invalidatedatacache("translations-" . $namespace . "-" . $language);
+        return (bool)$insert && (bool)$delete;
+    }
+}
+?>

--- a/systems/translationwizard/translationwizard/multichecked.php
+++ b/systems/translationwizard/translationwizard/multichecked.php
@@ -2,27 +2,39 @@
 declare(strict_types=1);
 $alrighty=true;
 foreach($transintext as $key=>$trans) {
-	if ($transouttext[$key]<>"")
-		{
-		$intext = $trans; //this comes in from the textarea and mustn't be decoded
-		$outtext = $transouttext[$key];
-		if ($nametext[$key]) $namespace=$nametext[$key];
-		$login = $session['user']['login'];
-		if ($translatedtid[$key]) {
-		$sql = "UPDATE " . db_prefix("translations") . " SET outtext='$outtext',author='$login',version='$logd_version' WHERE tid={$translatedtid[$key]};";
-		} else {
-		$sql = "INSERT INTO " . db_prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$languageschema','$namespace','$intext','$outtext','$login','$logd_version')";
-		}
-		$result1=db_query($sql);
-		invalidatedatacache("translations-".$namespace."-".$languageschema);
-		//debug($sql);
-		$sql = "DELETE FROM " . db_prefix("untranslated") . " WHERE intext = '$intext' AND language = '$languageschema' AND namespace = '$namespace'";
-		//debug($sql);
-		$result2=db_query($sql);
-		if (!$result1 || !$result2) $alrighty=false;
-		}
+        if ($transouttext[$key] != '') {
+                $intext = $trans; //this comes in from the textarea and mustn't be decoded
+                $outtext = $transouttext[$key];
+                if ($nametext[$key]) {
+                        $namespace=$nametext[$key];
+                }
+                $login = $session['user']['login'];
+                if ($translatedtid[$key]) {
+                        $sql = "UPDATE " . db_prefix("translations") . " SET outtext='$outtext',author='$login',version='$logd_version' WHERE tid={$translatedtid[$key]};";
+                        $result1 = db_query($sql);
+                } else {
+                        $result1 = WizardService::createTranslation(
+                                $languageschema,
+                                $namespace,
+                                $intext,
+                                $outtext,
+                                $login,
+                                $logd_version
+                        );
+                }
+                $result2 = WizardService::deleteUntranslated($languageschema,$namespace,$intext);
+                invalidatedatacache("translations-".$namespace."-".$languageschema);
+                if (!$result1 || !$result2) {
+                        $alrighty=false;
+                }
+        }
 }
-if (!$alrighty) $error=4;
-	else $error=5;
-if ($redirectonline) redirect("runmodule.php?module=translationwizard&op=list&ns=".$namespace."&error=".$error); //just redirecting 
+if (!$alrighty) {
+        $error=4;
+} else {
+        $error=5;
+}
+if ($redirectonline) {
+        redirect("runmodule.php?module=translationwizard&op=list&ns=".$namespace."&error=".$error);
+}
 ?>

--- a/systems/translationwizard/translationwizard/randomsave.php
+++ b/systems/translationwizard/translationwizard/randomsave.php
@@ -1,18 +1,20 @@
 <?php
-declare(strict_types=1);	
+declare(strict_types=1);
 $intext = httppost('intext');
 $outtext = httppost('outtext');
 $namespace = httppost('namespace');
 $language = httppost('language');
-if ($outtext <> "")	{
-	$login = $session['user']['login'];
-	$sql = "INSERT INTO " . db_prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$language','$namespace','$intext','$outtext','$login','$logd_version')";
-	$result1=db_query($sql);
-	$sql = "DELETE FROM " . db_prefix("untranslated") . " WHERE intext = '$intext' AND language = '$language' AND namespace = '$namespace'";
-	$result2=db_query($sql);
-	if (!$result1 || !$result2) $error=4;
-		else $error=5;
-	invalidatedatacache("translations-".$namespace."-".$languageschema);
+if ($outtext !== '') {
+        $login = $session['user']['login'];
+        $success = WizardService::saveTranslation(
+                $language,
+                $namespace,
+                $intext,
+                $outtext,
+                $login,
+                $logd_version
+        );
+        $error = $success ? 5 : 4;
 }
 redirect("runmodule.php?module=translationwizard&error=".$error); //just redirecting so you go back to the previous page after the save
 ?>

--- a/systems/translationwizard/translationwizard/save_single.php
+++ b/systems/translationwizard/translationwizard/save_single.php
@@ -2,15 +2,17 @@
 declare(strict_types=1);
 $intext = httppost('intext');
 $outtext = httppost('outtext');
-if ($outtext <> "") {
-	$login = $session['user']['login'];
-	$sql = "INSERT INTO " . db_prefix("translations") . " (language,uri,intext,outtext,author,version) VALUES" . " ('$languageschema','$namespace','$intext','$outtext','$login','$logd_version')";
-	$result1=db_query($sql);
-	$sql = "DELETE FROM " . db_prefix("untranslated") . " WHERE intext = '$intext' AND language = '$languageschema' AND namespace = '$namespace'";
-	$result2=db_query($sql);
-	if (!$result1 || !$result2) $error=4;
-		else $error=5;
-	invalidatedatacache("translations-".$namespace."-".$languageschema);
+if ($outtext !== '') {
+        $login = $session['user']['login'];
+        $success = WizardService::saveTranslation(
+                $languageschema,
+                $namespace,
+                $intext,
+                $outtext,
+                $login,
+                $logd_version
+        );
+        $error = $success ? 5 : 4;
 }
-redirect("runmodule.php?".$from."&error=".$error); //just redirecting so you go back to the previous page after the save	
+redirect("runmodule.php?".$from."&error=".$error); //just redirecting so you go back to the previous page after the save
 ?>


### PR DESCRIPTION
## Summary
- create `WizardService` with helpers for translation DB actions
- replace duplicate SQL in `randomsave.php`, `save_single.php` and `multichecked.php`
- load the service from `translationwizard.php`

## Testing
- `php -l systems/translationwizard/translationwizard/WizardService.php`
- `php -l systems/translationwizard/translationwizard/randomsave.php`
- `php -l systems/translationwizard/translationwizard/save_single.php`
- `php -l systems/translationwizard/translationwizard/multichecked.php`
- `php -l systems/translationwizard/translationwizard.php`


------
https://chatgpt.com/codex/tasks/task_e_6873c461c3a48329b018efb0067ed808