### PR TITLE
Add strict typing to translation wizard helper

### DIFF
--- a/systems/translationwizard/translationwizard/form_helpers.php
+++ b/systems/translationwizard/translationwizard/form_helpers.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 /**
  * Helper functions for Translation Wizard forms.
  */


### PR DESCRIPTION
## Summary
- enable strict types in translation wizard form helper

## Testing
- `php -l systems/translationwizard/translationwizard/form_helpers.php`

------
https://chatgpt.com/codex/tasks/task_e_6873cab2ca888329bbd3e25b80631d7c