### PR TITLE
Refactor wizard forms

### DIFF
--- a/systems/translationwizard/translationwizard/changescheme.php
+++ b/systems/translationwizard/translationwizard/changescheme.php
@@ -20,12 +20,12 @@ if (httppost('save'))
 		else
 		$set=array("language"=>$lang);//,"coding"=>$code);
 	require_once("lib/showform.php");
-	rawoutput("<form action='runmodule.php?module=translationwizard&op=changescheme' method='POST'>");
+        tw_form_open("changescheme", [], 'POST');
 	//output("Note: If you change your coding table, your php version must support the version. Else you'll get error messages.");
 	output_notl("`n`n");
 	$info = showform($settings,$set);
 	rawoutput("<input type='hidden' value='1' name='save'>");
-	rawoutput("</form>");
+        tw_form_close();
 	addnav("","runmodule.php?module=translationwizard&op=changescheme");
 	}
 

--- a/systems/translationwizard/translationwizard/deleteempty.php
+++ b/systems/translationwizard/translationwizard/deleteempty.php
@@ -49,19 +49,20 @@ switch ($mode)
 	default:  //if the user hits the button just to check for duplicates
 		$sql= "SELECT intext, language FROM  ".db_prefix("untranslated")." WHERE namespace='' GROUP  BY BINARY intext, language";
 		$result = db_query($sql);
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=deleteempty&mode=delete' method='post'>");
+                tw_form_open("deleteempty&mode=delete");
 		addnav("", "runmodule.php?module=translationwizard&op=deleteempty&mode=delete");
 		rawoutput("<input type='hidden' name='op' value='check'>");
 		output("`n`n %s rows have been found with no namespace in your untranslated table.`n`n",db_num_rows($result));
 		if (db_num_rows($result)==0) //table is fine, no redundant rows
 			{
 			output("Congratulations! Your untranslated table does not have any rows with an empty namespace!");
-			rawoutput("</form");
+                        tw_form_close();
 			break;
 			}
 		output("What do you want to do?`n`n`n`n");
-		rawoutput("<input type='submit' name='deleteall' value='". translate_inline("Delete multiple automatically") ."' class='button'>");
-		rawoutput("<input type='submit' name='listing' value='". translate_inline("Delete manually") ."' class='button'></form>");
+                rawoutput("<input type='submit' name='deleteall' value='". translate_inline("Delete multiple automatically") ."' class='button'>");
+                rawoutput("<input type='submit' name='listing' value='". translate_inline("Delete manually") ."' class='button'>");
+                tw_form_close();
 		output("`b`i`$ Attention, no additional confirmation`i`b`0");
 	break;
 		}

--- a/systems/translationwizard/translationwizard/edit_single.php
+++ b/systems/translationwizard/translationwizard/edit_single.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 if ($from=="") $from="module=translationwizard&op=list";
-rawoutput("<form action='runmodule.php?".$from."&mode=save&from=".rawurlencode($from)."' method='post'>");
+tw_form_open($from."&mode=save&from=".rawurlencode($from));
 addnav("", "runmodule.php?".$from."&mode=save&from=".rawurlencode($from));
 $sql = "SELECT namespace,count(*) AS c FROM " . db_prefix("untranslated") . " WHERE language='".$languageschema."' GROUP BY namespace ORDER BY namespace ASC";
 $result = db_query($sql);
@@ -23,5 +23,5 @@ while ($row = db_fetch_assoc($result))
 	rawoutput(translate_inline("Translation:"). "<br>");
 	rawoutput("<textarea name='outtext' class='input' cols='60' rows='5'>".htmlentities(stripslashes(httpget('outtext')),ENT_COMPAT,$coding)."</textarea><br/>");
 	rawoutput("<input type='submit' value='". translate_inline("Save") ."' class='button'>");
-	rawoutput("</form>");
+        tw_form_close();
 ?>

--- a/systems/translationwizard/translationwizard/editchecked.php
+++ b/systems/translationwizard/translationwizard/editchecked.php
@@ -32,6 +32,6 @@ foreach($transintext as $trans)
 	}
 output_notl("`n`n");
 rawoutput("<input type='submit' name='multichecked' value='". translate_inline("Save") ."' class='button'>");
-rawoutput("</form>");
+tw_form_close();
 
 ?>

--- a/systems/translationwizard/translationwizard/fix.php
+++ b/systems/translationwizard/translationwizard/fix.php
@@ -21,7 +21,7 @@ switch ($mode)
 		$result=db_query($sql);
 		if (db_num_rows($result)>0) 
 			{
-			rawoutput("<form action='runmodule.php?module=translationwizard&op=fix&mode=fix' method='post'>");
+                        tw_form_open("fix&mode=fix");
 			addnav("", "runmodule.php?module=translationwizard&op=fix&mode=fix");
 			output("`0There are %s entries who already have a translation in the translations table.`n`n",db_num_rows($result));
 			output("`0This operation will delete already translated parts from the untranslated table.`n`n`b`$ This operation can't be made undone!`b`0`n`n");
@@ -47,7 +47,7 @@ switch ($mode)
 			{
 			output("Congratulations! Your translation table does not have any redundant entries!");
 			}
-			rawoutput("</form>");
+                        tw_form_close();
 		break;
 	}
 ?>

--- a/systems/translationwizard/translationwizard/insert_central.php
+++ b/systems/translationwizard/translationwizard/insert_central.php
@@ -44,10 +44,10 @@ default:
 		output_notl("`n");
 		output("This may take some time.");
 		output_notl("`n`n");
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=insert_central&mode=continue' method='post'>");
+                tw_form_open("insert_central&mode=continue");
 		addnav("", "runmodule.php?module=translationwizard&op=insert_central&mode=continue");
 		rawoutput("<input type='submit' name='continue' value='". translate_inline("Commence the process")."' class='button'>");
-		rawoutput("</form>");
+                tw_form_close();
 	} else {
 		output("The pulled translations is empty, there is nothing to do!");
 	}

--- a/systems/translationwizard/translationwizard/known.php
+++ b/systems/translationwizard/translationwizard/known.php
@@ -140,7 +140,7 @@ if ($numberofallrows==0)
 	if ($central) output("`nSorry, all rows in the pulled translations table have no match in any intext in your translations table.");
 	break;
 	}
-rawoutput("<form action='runmodule.php?module=translationwizard&op=known$redirect' method='post'>");
+tw_form_open("known$redirect");
 addnav("", "runmodule.php?module=translationwizard&op=known$redirect");
 if (!httppost('quickinsert')) 
 	{
@@ -157,7 +157,7 @@ if (!httppost('quickinsert'))
 	rawoutput("<input type='submit' name='quickinsertexecute' value='". translate_inline("Quick Insert Execution") ."' class='button'>");
 	rawoutput("<input type='hidden' name='quickinsert' value='1' class='button'>");
 	}
-rawoutput("</form>");
+tw_form_close();
 $fastinsert=$result; //use the full result for insert purposes if the user wishes for, related to button -quick insert-
 $sql.=" LIMIT $start,$page;";
 //debug("Start: $start and $page and $numberofallrows");
@@ -222,7 +222,7 @@ $alttext= "abcdefgh-dummy-dummy-dummy"; //hopefully this text is in no module to
 			rawoutput("</table>");
 		
 	    } else if (db_num_rows($result)>0) {
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=known&mode=radioinsert$redirect' method='post'>");
+                tw_form_open("known&mode=radioinsert$redirect");
 		addnav("", "runmodule.php?module=translationwizard&op=known&mode=radioinsert$redirect");
 		rawoutput("<table border='0' cellpadding='2' cellspacing='0'>");
 		rawoutput("<tr class='trhead'><td>". translate_inline("Language") ."</td><td>". translate_inline("Original") ."</td><td>".translate_inline("Module / Translation")."</td><td>".translate_inline("Author")."</td><td>".translate_inline("Actions")."</td><td></td></tr>");			
@@ -265,10 +265,10 @@ $alttext= "abcdefgh-dummy-dummy-dummy"; //hopefully this text is in no module to
 				//if ($i>$page) break;  //would need previous/next page and one more if which needs too much time. better to get all now
 			}
 			}
-			rawoutput("</table>");
-			rawoutput("<input type='submit' value='". translate_inline("Insert checked translations") ."' class='button'>");
-			rawoutput("</form>");			
-		}
+                        rawoutput("</table>");
+                        rawoutput("<input type='submit' value='". translate_inline("Insert checked translations") ."' class='button'>");
+                        tw_form_close();
+                }
 	
 }
 ?>

--- a/systems/translationwizard/translationwizard/list.php
+++ b/systems/translationwizard/translationwizard/list.php
@@ -5,7 +5,7 @@ if (httppost("deletechecked")) {
 	require("./modules/translationwizard/deletechecked.php"); //if you want to delete the checked translations, this commences the deletion process
 }
 if (httppost("editchecked")) {
-	rawoutput("<form action='runmodule.php?module=translationwizard&op=list&ns=".rawurlencode($namespace)."' method='post'>");
+        tw_form_open("list&ns=".rawurlencode($namespace));
 	addnav("", "runmodule.php?module=translationwizard&op=list&ns=".rawurlencode($namespace));
 	$sql = "SELECT namespace,count(*) AS c FROM " . db_prefix("untranslated") . " WHERE language='".$languageschema."' GROUP BY namespace ORDER BY namespace ASC";
 	$result = db_query($sql);

--- a/systems/translationwizard/translationwizard/push.php
+++ b/systems/translationwizard/translationwizard/push.php
@@ -16,7 +16,7 @@ case "push":
 	output_notl("`n`n");
 	$sql = "SELECT uri,count(*) AS c FROM " . db_prefix("translations") . " WHERE language='".$selectedlanguage."' GROUP BY uri ORDER BY uri ASC";
 	$res=db_query($sql);
-	rawoutput("<form action='runmodule.php?module=translationwizard&op=push&mode=push' method='post'>");
+        tw_form_open("push&mode=push");
 	addnav("", "runmodule.php?module=translationwizard&op=push&mode=push");
 	rawoutput("<input type='hidden' name='op' value='push'>");
 	rawoutput("<input type='hidden' name='mode' value='push'>");
@@ -27,7 +27,7 @@ case "push":
 		rawoutput("<option value=\"".htmlentities($row['uri'],ENT_COMPAT,$coding)."\"".((htmlentities($row['uri'],ENT_COMPAT,$coding) == $namespace) ? "selected" : "").">".htmlentities($row['uri'],ENT_COMPAT,$coding)." ({$row['c']})</option>");
 		}
 	rawoutput("</select>");
-	rawoutput("</form>");
+        tw_form_close();
 	output_notl("`n`n");
 	output_notl($currentdate." Verified "."Uploader:".$session['user']['login']." Time:".$currenttime);
 	$start="('";

--- a/systems/translationwizard/translationwizard/scanmodules.php
+++ b/systems/translationwizard/translationwizard/scanmodules.php
@@ -57,7 +57,7 @@ case "insert":
 		TranslationWizard::insertFile($transintext,$languageschema,true);
 		redirect('runmodule.php?module=translationwizard&op=scanmodules&error=1'); //back to the roots, no error but success
 	} else { //if edit button was pushed
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=scanmodules&mode=saveedited' method='post'>");
+                tw_form_open("scanmodules&mode=saveedited");
 		addnav("", "runmodule.php?module=translationwizard&op=scanmodules&mode=saveedited");
 		//rawoutput("<input type='submit' class='button' value='". translate_inline("Show") ."'>"); //no longer necessary
 		require("./modules/translationwizard/editchecked.php"); //if you want to edit some translations at a time

--- a/systems/translationwizard/translationwizard/searchandedit.php
+++ b/systems/translationwizard/translationwizard/searchandedit.php
@@ -145,7 +145,7 @@ switch ($mode)
 				//end		
 				if (db_num_rows($result)>1) rawoutput("<input type='button' onClick='this.value=check()' name='allcheck' value='". $all ."' class='button'>");
 				rawoutput("<input type='submit' name='deletechecked' value='". translate_inline("Delete selected") ."' class='button'>");
-				rawoutput("</form>");
+                                tw_form_close();
 				break;
 
 	case "edit":
@@ -158,7 +158,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you want to abort, just click abort (or any other navigation except 'save'.");
 				output_notl("`n`n");
-				rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandedit&mode=save' method='post'>");
+                                tw_form_open("searchandedit&mode=save");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandedit&mode=save");
 				output("TID of the row:");
 				rawoutput("<input id='input' name='tid' width=5 maxlength=5 value='".$row['tid']."'>");
@@ -186,7 +186,7 @@ switch ($mode)
 				rawoutput("<input type='submit' name='select' value='". translate_inline("Save")."' class='button'>");
 				output("`b`$ ATTENTION`b`0");
 				rawoutput("<input type='submit' name='abort' value='". translate_inline("Abort")."' class='button'>");
-				rawoutput("</form>");	
+                                tw_form_close();
 				break;
 
 	case "save":
@@ -252,7 +252,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you don't want that, just hit the checkbox below. You may use ?,% or the like in the text."); 
 				output_notl("`n`n");
-				rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandedit&mode=select' method='post'>");
+                                tw_form_open("searchandedit&mode=select");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandedit&mode=select");
 				output("What do you want to search for (select enter one or more criteria):");
 				output_notl("`n`n");

--- a/systems/translationwizard/translationwizard/searchandreplace.php
+++ b/systems/translationwizard/translationwizard/searchandreplace.php
@@ -145,7 +145,7 @@ switch ($mode)
 				//end		
 				if (db_num_rows($result)>1) rawoutput("<input type='button' onClick='this.value=check()' name='allcheck' value='". $all ."' class='button'>");
 				rawoutput("<input type='submit' name='replacechecked' value='". translate_inline("Replace in selected") ."' class='button'>");
-				rawoutput("</form>");
+                                tw_form_close();
 				break;
 
 	case "edit":
@@ -158,7 +158,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you want to abort, just click abort (or any other navigation except 'save'.");
 				output_notl("`n`n");
-				rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandreplace&mode=save' method='post'>");
+                                tw_form_open("searchandreplace&mode=save");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandreplace&mode=save");
 				output("TID of the row:");
 				rawoutput("<input id='input' name='tid' width=5 maxlength=5 value='".$row['tid']."'>");
@@ -184,7 +184,7 @@ switch ($mode)
 				rawoutput("<input type='submit' name='select' value='". translate_inline("Save")."' class='button'>");
 				output("`b`$ ATTENTION`b`0");
 				rawoutput("<input type='submit' name='abort' value='". translate_inline("Abort")."' class='button'>");
-				rawoutput("</form>");	
+                                tw_form_close();
 				break;
 
 	case "save":
@@ -263,7 +263,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you don't want that, just hit the checkbox below. You may use ?,% or the like in the text."); 
 				output_notl("`n`n");
-				rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandreplace&mode=select' method='post'>");
+                                tw_form_open("searchandreplace&mode=select");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandreplace&mode=select");
 				output("What do you want to search for (select enter one or more criteria):");
 				output_notl("`n`n");
@@ -339,7 +339,7 @@ switch ($mode)
 				rawoutput("<input id='input' name='rversion' width=20 maxlength=50 value='".$query['rversion']."'>");
 				rawoutput("<input id='input' name='rversion2' width=20 maxlength=50 value='".$query['rversion2']."'>");
 
-				rawoutput("<input type='submit' name='select' value='". translate_inline("Preview")."' class='button'>");
-				rawoutput("</form>");
+                                rawoutput("<input type='submit' name='select' value='". translate_inline("Preview")."' class='button'>");
+                                tw_form_close();
 }
 ?>

--- a/systems/translationwizard/translationwizard/truncate.php
+++ b/systems/translationwizard/translationwizard/truncate.php
@@ -22,11 +22,12 @@ switch ($mode)
 		$result = db_query($sql);
 			break;
 		default:  //if the user hits the button just to check for duplicates
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=truncate$redirect&mode=truncate' method='post'>");
+                tw_form_open("truncate$redirect&mode=truncate");
 		addnav("", "runmodule.php?module=translationwizard&op=truncate$redirect&mode=truncate");
 			if (!$central) output("`0This operation will truncate the untranslated table.`n`n`b`$ This operation can't be made undone!`b`0`n`n");
 		if ($central)  output("`0This operation will truncate the pulled translations table.`n`n`b`$ This operation can't be made undone!`b`0`n`n");
-		rawoutput("<input type='submit' value='". translate_inline("Execute") ."' class='button'>");
-		break;
+                rawoutput("<input type='submit' value='". translate_inline("Execute") ."' class='button'>");
+                tw_form_close();
+                break;
 	}
 ?>


### PR DESCRIPTION
## Summary
- use `tw_form_open()` and `tw_form_close()` in Translation Wizard pages
- leave forms with special name attributes untouched

## Testing
- `php -l systems/translationwizard/translationwizard/changescheme.php`
- `php -l systems/translationwizard/translationwizard/deleteempty.php`
- `php -l systems/translationwizard/translationwizard/edit_single.php`
- `php -l systems/translationwizard/translationwizard/editchecked.php`
- `php -l systems/translationwizard/translationwizard/fix.php`
- `php -l systems/translationwizard/translationwizard/insert_central.php`
- `php -l systems/translationwizard/translationwizard/known.php`
- `php -l systems/translationwizard/translationwizard/list.php`
- `php -l systems/translationwizard/translationwizard/push.php`
- `php -l systems/translationwizard/translationwizard/scanmodules.php`
- `php -l systems/translationwizard/translationwizard/searchandedit.php`
- `php -l systems/translationwizard/translationwizard/searchandreplace.php`
- `php -l systems/translationwizard/translationwizard/truncate.php`


------
https://chatgpt.com/codex/tasks/task_e_6873cfa5f8f08329883b84325ba0db59