### PR TITLE
Replace legacy translation saves with service calls

### DIFF
--- a/systems/translationwizard/translationwizard/known.php
+++ b/systems/translationwizard/translationwizard/known.php
@@ -11,9 +11,22 @@ if ($central)
 switch($mode)
 {
 case "save":		//if you want to save a single translation from Edit+Insert
-	require("./modules/translationwizard/save_single.php");
-break; //just in case
 
+        $from="module=translationwizard&op=known$redirect&ns=".$namespace;
+        $outtext = httppost('outtext');
+        if ($outtext !== '') {
+                $success = WizardService::saveTranslation(
+                        $languageschema,
+                        $namespace,
+                        httppost('intext'),
+                        $outtext,
+                        $session['user']['login'],
+                        $logd_version
+                );
+                $error = $success ? 5 : 4;
+        }
+        redirect("runmodule.php?{$from}&error=".(isset($error) ? $error : ''));
+        break; //just in case
 case "picked": //save the picked one
 	$intext=rawurldecode(httpget('intext'));
 	$outtext=rawurldecode(httpget('outtext'));

--- a/systems/translationwizard/translationwizard/list.php
+++ b/systems/translationwizard/translationwizard/list.php
@@ -55,12 +55,24 @@ if (httppost("copychecked")) {
 switch ($mode)
 {
 case "save":		//if you want to save a single translation (called not from the checkboxes form)
-	$from="module=translationwizard&op=list&ns=".$namespace;
-	require("./modules/translationwizard/save_single.php");
-	break; //just in case
+        $from="module=translationwizard&op=list&ns=".$namespace;
+        $outtext = httppost('outtext');
+        if ($outtext !== '') {
+                $success = WizardService::saveTranslation(
+                        $languageschema,
+                        $namespace,
+                        httppost('intext'),
+                        $outtext,
+                        $session['user']['login'],
+                        $logd_version
+                );
+                $error = $success ? 5 : 4;
+        }
+        redirect("runmodule.php?{$from}&error=".(isset($error) ? $error : ''));
+        break; //just in case
 case "edit": //for one translation via the edit button
-	require("./modules/translationwizard/edit_single.php");
-	break;
+        require("./modules/translationwizard/edit_single.php");
+        break;
 case "del": //to delete one via the delete button
 	$intext=rawurldecode(httpget('intext'));
 	$sql = "DELETE FROM " . db_prefix("untranslated") . " WHERE intext = '$intext' AND language = '$languageschema' AND namespace = '$namespace'";

--- a/systems/translationwizard/translationwizard/scanmodules.php
+++ b/systems/translationwizard/translationwizard/scanmodules.php
@@ -66,7 +66,16 @@ case "insert":
 
 case "saveedited":
 	$redirectonline=0;
-	require("./modules/translationwizard/multichecked.php");//if you want to copy the checked translations with intext and the entered outtext, this commences the copy process
+        $success = WizardService::saveBatchTranslations(
+                $languageschema,
+                $namespace,
+                WizardService::ensureArray($transintext),
+                WizardService::ensureArray($transouttext),
+                WizardService::ensureArray($nametext),
+                WizardService::ensureArray($translatedtid),
+                $session["user"]["login"],
+                $logd_version
+        );
 	output("Job done");
 	break;
 	


### PR DESCRIPTION
## Summary
- refactor save actions in the Translation Wizard to call `WizardService`
- remove outdated includes for `save_single.php` and `multichecked.php`

## Testing
- `php -l systems/translationwizard/translationwizard/list.php`
- `php -l systems/translationwizard/translationwizard/known.php`
- `php -l systems/translationwizard/translationwizard/scanmodules.php`


------
https://chatgpt.com/codex/tasks/task_e_6873e04d495c8329a02fd4a234ef1111