### PR TITLE
Improve translation wizard forms

### DIFF
--- a/systems/translationwizard/translationwizard/default.php
+++ b/systems/translationwizard/translationwizard/default.php
@@ -8,8 +8,9 @@ if ($count['count'] > 0) {
 	if (db_num_rows($result) == 1) {
 		$row = db_fetch_assoc($result);
 		$row['intext'] = stripslashes($row['intext']);
-		$submit = translate_inline("Save Translation");
-		$skip = translate_inline("Skip Translation");
+                $submit = translate_inline("Save Translation");
+                $skip = translate_inline("Skip Translation");
+                output("Translate the text below:");
                 tw_form_open('randomsave', [
                     'id'        => $row['id'],
                     'language'  => $row['language'],
@@ -23,8 +24,8 @@ if ($count['count'] > 0) {
 		rawoutput("<tr><td width='30%'>");
 		output("Namespace: %s", $row['namespace']);
 		rawoutput("</td><td></td></tr>");
-		rawoutput("<tr><td width='30%'><textarea cols='35' rows='4' name='intext' readonly>".$row['intext']."</textarea></td>");
-		rawoutput("<td width='30%'><textarea cols='25' rows='4' name='outtext'></textarea></td></tr></table>");
+                rawoutput("<tr><td width='30%'><textarea cols='35' rows='4' name='intext' readonly title=\"".translate_inline('Original text')."\">".$row['intext']."</textarea></td>");
+                rawoutput("<td width='30%'><textarea cols='25' rows='4' name='outtext' title=\"".translate_inline('Enter your translation')."\"></textarea></td></tr></table>");
                 tw_form_close($submit);
                 tw_form_open('');
                 tw_form_close($skip);

--- a/systems/translationwizard/translationwizard/edit_single.php
+++ b/systems/translationwizard/translationwizard/edit_single.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 if ($from=="") $from="module=translationwizard&op=list";
+output("Edit the translation below:");
 tw_form_open($from."&mode=save&from=".rawurlencode($from));
 addnav("", "runmodule.php?".$from."&mode=save&from=".rawurlencode($from));
 $sql = "SELECT namespace,count(*) AS c FROM " . db_prefix("untranslated") . " WHERE language='".$languageschema."' GROUP BY namespace ORDER BY namespace ASC";
@@ -19,9 +20,9 @@ while ($row = db_fetch_assoc($result))
 	//rawoutput("<input type='submit' class='button' value='". translate_inline("Show") ."'>"); //no longer necessary
 	rawoutput("<br>");
 	rawoutput(translate_inline("Text:"). "<br>");
-	rawoutput("<textarea name='intext' class='input' cols='60' rows='5' readonly>".htmlentities(stripslashes(httpget('intext')),ENT_COMPAT,$coding)."</textarea><br/>");
-	rawoutput(translate_inline("Translation:"). "<br>");
-	rawoutput("<textarea name='outtext' class='input' cols='60' rows='5'>".htmlentities(stripslashes(httpget('outtext')),ENT_COMPAT,$coding)."</textarea><br/>");
+       rawoutput("<textarea name='intext' class='input' cols='60' rows='5' readonly title=\"".translate_inline('Original text')."\">".htmlentities(stripslashes(httpget('intext')),ENT_COMPAT,$coding)."</textarea><br/>");
+        rawoutput(translate_inline("Translation:"). "<br>");
+       rawoutput("<textarea name='outtext' class='input' cols='60' rows='5' title=\"".translate_inline('Enter your translation')."\">".htmlentities(stripslashes(httpget('outtext')),ENT_COMPAT,$coding)."</textarea><br/>");
 	rawoutput("<input type='submit' value='". translate_inline("Save") ."' class='button'>");
         tw_form_close();
 ?>

--- a/systems/translationwizard/translationwizard/editchecked.php
+++ b/systems/translationwizard/translationwizard/editchecked.php
@@ -3,7 +3,8 @@ declare(strict_types=1);
 
 rawoutput("<br>");
 output("`n`bBeware of the autologoff-timeout!`b`n`n");
-foreach($transintext as $trans) 
+output("Edit the translations below:");
+foreach($transintext as $trans)
 	{
 		output("Text:");
 		output_notl("`n");

--- a/systems/translationwizard/translationwizard/list.php
+++ b/systems/translationwizard/translationwizard/list.php
@@ -5,6 +5,7 @@ if (httppost("deletechecked")) {
 	require("./modules/translationwizard/deletechecked.php"); //if you want to delete the checked translations, this commences the deletion process
 }
 if (httppost("editchecked")) {
+        output("Edit the selected texts below:");
         tw_form_open("list&ns=".rawurlencode($namespace));
 	addnav("", "runmodule.php?module=translationwizard&op=list&ns=".rawurlencode($namespace));
 	$sql = "SELECT namespace,count(*) AS c FROM " . db_prefix("untranslated") . " WHERE language='".$languageschema."' GROUP BY namespace ORDER BY namespace ASC";
@@ -82,7 +83,8 @@ case "del": //to delete one via the delete button
 	redirect("runmodule.php?module=translationwizard&op=list&ns=".$namespace); //just redirecting so you go back to the previous page after the deletion
 	break;
 default: //if there is any other mode, i.e. "" go on and display what's necessary including checkboxes and so on, just the main list
-	rawoutput("<form action='runmodule.php?module=translationwizard&op=list' name='listenauswahl' method='post'>");
+        output("Select texts to translate or delete:");
+        rawoutput("<form action='runmodule.php?module=translationwizard&op=list' name='listenauswahl' method='post'>");
 	addnav("", "runmodule.php?module=translationwizard&op=list");
 	$sql = "SELECT namespace,count(*) AS c FROM " . db_prefix("untranslated") . " WHERE language='".$languageschema."' GROUP BY namespace ORDER BY namespace ASC";
 	$result = db_query($sql);

--- a/systems/translationwizard/translationwizard/pull.php
+++ b/systems/translationwizard/translationwizard/pull.php
@@ -79,9 +79,10 @@ switch($mode) {
 		$linklist=pullurl($path."files.txt"); debug($path."files.txt");
 		$mirrors=pullurl($masterpath."mirrors.txt");
 		if (is_array($mirrors)) sort ($mirrors);
-		output("Choose a mirror if you don't want to use the normal central DB:");
-		output_notl("`n");debug($mymirror);
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=pull' name='listenauswahl' method='post'>");
+                output("Choose a mirror if you don't want to use the normal central DB:");
+                output_notl("`n");debug($mymirror);
+                output("Select a mirror and directory to pull from:");
+                rawoutput("<form action='runmodule.php?module=translationwizard&op=pull' name='listenauswahl' method='post'>");
 		addnav("", "runmodule.php?module=translationwizard&op=pull");	
 		rawoutput("<select name='mirror' onchange='this.form.submit()'>");
 		rawoutput("<option value=''>---</option>");

--- a/systems/translationwizard/translationwizard/push.php
+++ b/systems/translationwizard/translationwizard/push.php
@@ -16,7 +16,7 @@ case "push":
 	output_notl("`n`n");
 	$sql = "SELECT uri,count(*) AS c FROM " . db_prefix("translations") . " WHERE language='".$selectedlanguage."' GROUP BY uri ORDER BY uri ASC";
         $res=db_query($sql);
-        output("Choose the namespace to push:");
+        output("Select the namespace to push:");
         tw_form_open("push&mode=push");
 	addnav("", "runmodule.php?module=translationwizard&op=push&mode=push");
 	rawoutput("<input type='hidden' name='op' value='push'>");

--- a/systems/translationwizard/translationwizard/push.php
+++ b/systems/translationwizard/translationwizard/push.php
@@ -15,7 +15,8 @@ case "push":
 	output("Please copy the following code to a file named `b`^%s.sql`0`b and give it to the admin for your language:",$namespace);
 	output_notl("`n`n");
 	$sql = "SELECT uri,count(*) AS c FROM " . db_prefix("translations") . " WHERE language='".$selectedlanguage."' GROUP BY uri ORDER BY uri ASC";
-	$res=db_query($sql);
+        $res=db_query($sql);
+        output("Choose the namespace to push:");
         tw_form_open("push&mode=push");
 	addnav("", "runmodule.php?module=translationwizard&op=push&mode=push");
 	rawoutput("<input type='hidden' name='op' value='push'>");
@@ -97,9 +98,10 @@ case "push":
 			}
 		break;
 default:
-	output("Choose the language you want to push:");
-	output_notl("`n");
-	rawoutput("<form action='runmodule.php?module=translationwizard&op=push' name='pushi' method='post'>");
+        output("Choose the language you want to push:");
+        output_notl("`n");
+        output("Select language and namespaces to push:");
+        rawoutput("<form action='runmodule.php?module=translationwizard&op=push' name='pushi' method='post'>");
 	addnav("", "runmodule.php?module=translationwizard&op=push");	
 	rawoutput("<select name='pushlanguage' onChange='this.form.submit()'>");
 	$sql = "SELECT language,count(*) AS c FROM " . db_prefix("translations") . " GROUP BY language ORDER BY language ASC";

--- a/systems/translationwizard/translationwizard/searchandedit.php
+++ b/systems/translationwizard/translationwizard/searchandedit.php
@@ -74,7 +74,8 @@ switch ($mode)
 		$result=db_query($sql);
 		$rownumber=db_num_rows($result);
 		if ($rownumber==0) redirect('runmodule.php?module=translationwizard&op=searchandedit&error=2'); //back to the roots if nothing was found
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandedit&mode=delete' name='editfeld' method='post' >");
+                output("Select translations to delete:");
+                rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandedit&mode=delete' name='editfeld' method='post' >");
 		addnav("", "runmodule.php?module=translationwizard&op=searchandedit&mode=delete");
 		output("%s rows have been found (Displaylimit was %s).",$numberofallrows,$numberof);
 		output_notl("`n");
@@ -158,6 +159,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you want to abort, just click abort (or any other navigation except 'save'.");
 				output_notl("`n`n");
+                                output("Edit the selected translation:");
                                 tw_form_open("searchandedit&mode=save");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandedit&mode=save");
 				output("TID of the row:");
@@ -171,11 +173,11 @@ switch ($mode)
 				output_notl("`n`n");
 				output("Intext of the row:");
 				output_notl("`n");
-				rawoutput("<textarea name='intext' class='input' cols='60' rows='5'>".htmlentities(stripslashes($row['intext']),ENT_COMPAT,$coding)."</textarea>");
+                                rawoutput("<textarea name='intext' class='input' cols='60' rows='5' title=\"".translate_inline('Original text')."\">".htmlentities(stripslashes($row['intext']),ENT_COMPAT,$coding)."</textarea>");
 				output_notl("`n`n");
 				output("Outtext of the row:");
 				output_notl("`n");
-				rawoutput("<textarea name='outtext' class='input' cols='60' rows='5'>".htmlentities(stripslashes($row['outtext']),ENT_COMPAT,$coding)."</textarea>");
+                                rawoutput("<textarea name='outtext' class='input' cols='60' rows='5' title=\"".translate_inline('Enter your translation')."\">".htmlentities(stripslashes($row['outtext']),ENT_COMPAT,$coding)."</textarea>");
 				output_notl("`n`n");	
 				output("Author of the row:");
 				rawoutput("<input id='input' name='author' width=50 maxlength=50 value='".$row['author']."'>");
@@ -252,6 +254,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you don't want that, just hit the checkbox below. You may use ?,% or the like in the text."); 
 				output_notl("`n`n");
+                                output("Enter part of the translation to search for:");
                                 tw_form_open("searchandedit&mode=select");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandedit&mode=select");
 				output("What do you want to search for (select enter one or more criteria):");
@@ -284,11 +287,11 @@ switch ($mode)
 				output_notl("`n`n");
 				output("Intext of the row:");
 				output_notl("`n");
-				rawoutput("<textarea name='intext' class='input' cols='60' rows='5'>".$query['intext']."</textarea>");
+                                rawoutput("<textarea name='intext' class='input' cols='60' rows='5' title=\"".translate_inline('Original text')."\">".$query['intext']."</textarea>");
 				output_notl("`n`n");
 				output("Outtext of the row:");
 				output_notl("`n");
-				rawoutput("<textarea name='outtext' class='input' cols='60' rows='5'>".$query['outtext']."</textarea>");
+                                rawoutput("<textarea name='outtext' class='input' cols='60' rows='5' title=\"".translate_inline('Enter your translation')."\">".$query['outtext']."</textarea>");
 				output_notl("`n`n");	
 				output("Author of the row:");
 				rawoutput("<input id='input' name='author' width=50 maxlength=50 value='".$query['author']."'>");

--- a/systems/translationwizard/translationwizard/searchandreplace.php
+++ b/systems/translationwizard/translationwizard/searchandreplace.php
@@ -74,7 +74,8 @@ switch ($mode)
 		$result=db_query($sql);
 		$rownumber=db_num_rows($result);
 		if ($rownumber==0) redirect('runmodule.php?module=translationwizard&op=searchandreplace&error=2'); //back to the roots if nothing was found
-		rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandreplace&mode=replace' name='editfeld' method='post' >");
+                output("Select translations to replace:");
+                rawoutput("<form action='runmodule.php?module=translationwizard&op=searchandreplace&mode=replace' name='editfeld' method='post' >");
 		addnav("", "runmodule.php?module=translationwizard&op=searchandreplace&mode=replace");
 		output("%s rows have been found (Displaylimit was %s).",$numberofallrows,$numberof);
 		output_notl("`n");
@@ -158,6 +159,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you want to abort, just click abort (or any other navigation except 'save'.");
 				output_notl("`n`n");
+                                output("Edit the selected translation:");
                                 tw_form_open("searchandreplace&mode=save");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandreplace&mode=save");
 				output("TID of the row:");
@@ -170,10 +172,10 @@ switch ($mode)
 				rawoutput("<input id='uri' name='uri' width=65 maxlength=255 value='".$row['uri']."'>");
 				output_notl("`n`n");
 				output("Intext of the row:");
-				rawoutput("<textarea name='intext' class='input' cols='60' rows='5'>".htmlentities(stripslashes($row['intext']),ENT_COMPAT,$coding)."</textarea>");
+                                rawoutput("<textarea name='intext' class='input' cols='60' rows='5' title=\"".translate_inline('Original text')."\">".htmlentities(stripslashes($row['intext']),ENT_COMPAT,$coding)."</textarea>");
 				output_notl("`n`n");
 				output("Outtext of the row:");
-				rawoutput("<textarea name='outtext' class='input' cols='60' rows='5'>".htmlentities(stripslashes($row['outtext']),ENT_COMPAT,$coding)."</textarea>");
+                                rawoutput("<textarea name='outtext' class='input' cols='60' rows='5' title=\"".translate_inline('Enter your translation')."\">".htmlentities(stripslashes($row['outtext']),ENT_COMPAT,$coding)."</textarea>");
 				output_notl("`n`n");	
 				output("Author of the row:");
 				rawoutput("<input id='input' name='author' width=50 maxlength=50 value='".$row['author']."'>");
@@ -263,6 +265,7 @@ switch ($mode)
 				output_notl(" ");
 				output("If you don't want that, just hit the checkbox below. You may use ?,% or the like in the text."); 
 				output_notl("`n`n");
+                                output("Enter part of the translation to search for:");
                                 tw_form_open("searchandreplace&mode=select");
 				addnav("", "runmodule.php?module=translationwizard&op=searchandreplace&mode=select");
 				output("What do you want to search for (select enter one or more criteria):");
@@ -295,11 +298,11 @@ switch ($mode)
 				output_notl("`n`n");
 				output("Intext of the row:");
 				output_notl("`n");
-				rawoutput("<textarea name='intext' class='input' cols='60' rows='5'>".$query['intext']."</textarea>");
+                                rawoutput("<textarea name='intext' class='input' cols='60' rows='5' title=\"".translate_inline('Original text')."\">".$query['intext']."</textarea>");
 				output_notl("`n`n");
 				output("Outtext of the row:");
 				output_notl("`n");
-				rawoutput("<textarea name='outtext' class='input' cols='60' rows='5'>".$query['outtext']."</textarea>");
+                                rawoutput("<textarea name='outtext' class='input' cols='60' rows='5' title=\"".translate_inline('Enter your translation')."\">".$query['outtext']."</textarea>");
 				output_notl("`n`n");	
 				output("Author of the row:");
 				rawoutput("<input id='input' name='author' width=50 maxlength=50 value='".$query['author']."'>");


### PR DESCRIPTION
## Summary
- add step descriptions before forms
- explain original and translation boxes via title attributes
- make title attributes translatable

## Testing
- `php -l systems/translationwizard/translationwizard/default.php`
- `php -l systems/translationwizard/translationwizard/edit_single.php`
- `php -l systems/translationwizard/translationwizard/searchandedit.php`
- `php -l systems/translationwizard/translationwizard/searchandreplace.php`


------
https://chatgpt.com/codex/tasks/task_e_6873f58ec3d88329be6200d3331caed8