### PR TITLE
Add table helper & refactor wizard tables

### DIFF
--- a/systems/translationwizard/translationwizard/check.php
+++ b/systems/translationwizard/translationwizard/check.php
@@ -45,36 +45,37 @@ switch ($mode)
 		output("`n`n %s rows have been found not to be unique within your translations table.`n`n",db_num_rows($result));
 		$i = 0;
 		output("`n`nFollowing rows are non-unique:");
-		rawoutput("<table border='0' cellpadding='2' cellspacing='0'>");
-		rawoutput("<tr class='trhead'><td>". translate_inline("Language")."</td><td>".translate_inline("Namespace")."</td><td>".translate_inline("Original") ."</td><td>".translate_inline("Translation")."</td><td>".translate_inline("Author")."</td><td>".translate_inline("Version")."</td><td>".translate_inline("Actions")."</td></tr>");
-		while ($row = db_fetch_assoc($result))
-			{
-			$i++;
-			rawoutput("<tr class='".($i%2?"trlight":"trdark")."'>");
-			$sql="SELECT * FROM ".db_prefix("translations")." WHERE intext='".addslashes($row['intext'])."' AND language='".$row['language']."' AND uri='".$row['uri']."';";
-			$result2 = db_query($sql);
-				while ($row2 = db_fetch_assoc($result2))
-				{
-				rawoutput("<td>");
-				rawoutput(htmlentities($row2['language'],ENT_COMPAT,$coding));
-				rawoutput("</td><td>");
-				rawoutput(htmlentities($row2['uri'],ENT_COMPAT,$coding));
-				rawoutput("</td><td>");
-				rawoutput(htmlentities($row2['intext'],ENT_COMPAT,$coding));
-				rawoutput("</td><td>");
-				rawoutput(htmlentities($row2['outtext'],ENT_COMPAT,$coding));
-				rawoutput("</td><td>");
-				rawoutput(htmlentities($row2['author'],ENT_COMPAT,$coding));
-				rawoutput("</td><td>");
-				rawoutput(htmlentities($row2['version'],ENT_COMPAT,$coding));
-				rawoutput("</td><td>");
-				rawoutput("<a href='runmodule.php?module=translationwizard&op=check&mode=del&tid=". $row2['tid'] ."'>". translate_inline("Delete") ."</a>");
-				addnav("", "runmodule.php?module=translationwizard&op=check&mode=del&tid=". $row2['tid']);
-				rawoutput("</td></tr>");
-				}
-			if ($i>$page) break;
-			}
-		rawoutput("</table>");
+                tw_table_open([
+                    translate_inline("Language"),
+                    translate_inline("Namespace"),
+                    translate_inline("Original Text"),
+                    translate_inline("Translation"),
+                    translate_inline("Author"),
+                    translate_inline("Version"),
+                    translate_inline("Actions"),
+                ]);
+                while ($row = db_fetch_assoc($result))
+                        {
+                        $sql="SELECT * FROM ".db_prefix("translations")." WHERE intext='".addslashes($row['intext'])."' AND language='".$row['language']."' AND uri='".$row['uri']."';";
+                        $result2 = db_query($sql);
+                                while ($row2 = db_fetch_assoc($result2))
+                                {
+                                    $i++;
+                                    $actions = "<a href='runmodule.php?module=translationwizard&op=check&mode=del&tid=". $row2['tid'] ."'>". translate_inline("Delete") ."</a>";
+                                    addnav("", "runmodule.php?module=translationwizard&op=check&mode=del&tid=". $row2['tid']);
+                                    tw_table_row([
+                                        htmlentities($row2['language'],ENT_COMPAT,$coding),
+                                        htmlentities($row2['uri'],ENT_COMPAT,$coding),
+                                        htmlentities($row2['intext'],ENT_COMPAT,$coding),
+                                        htmlentities($row2['outtext'],ENT_COMPAT,$coding),
+                                        htmlentities($row2['author'],ENT_COMPAT,$coding),
+                                        htmlentities($row2['version'],ENT_COMPAT,$coding),
+                                        $actions,
+                                    ], $i%2==1);
+                                    if ($i>$page) break 2;
+                                }
+                        }
+                tw_table_close();
 	break;
 
 	case "deleteall":

--- a/systems/translationwizard/translationwizard/form_helpers.php
+++ b/systems/translationwizard/translationwizard/form_helpers.php
@@ -28,4 +28,40 @@ function tw_form_close(?string $label = null): void
     rawoutput('</form>');
 }
 
+/**
+ * Open a table and optionally output a header row.
+ */
+function tw_table_open(array $headers = []): void
+{
+    rawoutput("<table border='0' cellpadding='2' cellspacing='0'>");
+    if ([] !== $headers) {
+        rawoutput("<tr class='trhead'>");
+        foreach ($headers as $header) {
+            $header = htmlspecialchars((string)$header, ENT_COMPAT, getsetting('charset', 'ISO-8859-1'));
+            rawoutput("<td>{$header}</td>");
+        }
+        rawoutput('</tr>');
+    }
+}
+
+/**
+ * Output a table row with alternating row classes.
+ */
+function tw_table_row(array $cells, bool $odd): void
+{
+    rawoutput("<tr class='" . ($odd ? 'trlight' : 'trdark') . "'>");
+    foreach ($cells as $cell) {
+        rawoutput("<td>{$cell}</td>");
+    }
+    rawoutput('</tr>');
+}
+
+/**
+ * Close a table.
+ */
+function tw_table_close(): void
+{
+    rawoutput('</table>');
+}
+
 

--- a/systems/translationwizard/translationwizard/list.php
+++ b/systems/translationwizard/translationwizard/list.php
@@ -101,8 +101,11 @@ default: //if there is any other mode, i.e. "" go on and display what's necessar
 	addnav("", "runmodule.php?module=translationwizard&op=pull&mode=pull&ns=". rawurlencode($namespace));
 	//rawoutput("<input type='submit' class='button' name='dummy' value='". translate_inline("Show") ."'>"); //no longer necessary
 	output_notl("`n");
-	rawoutput("<table border='0' cellpadding='2' cellspacing='0'>");
-	rawoutput("<tr class='trhead'><td>". translate_inline("Ops") ."</td><td>". translate_inline("Text") ."</td><td>".translate_inline("Actions")."</td></tr>");
+        tw_table_open([
+            translate_inline("Ops"),
+            translate_inline("Text"),
+            translate_inline("Actions"),
+        ]);
 	$sql = "SELECT * FROM " . db_prefix("untranslated") . " WHERE language='".$languageschema."' AND namespace='".$namespace."'";
 	$result = db_query($sql);
 	if (db_num_rows($result)>0){
@@ -110,28 +113,27 @@ default: //if there is any other mode, i.e. "" go on and display what's necessar
 		while ($row = db_fetch_assoc($result))
 		{
 			$i++;
-			rawoutput("<tr class='".($i%2?"trlight":"trdark")."'><td>");
-			rawoutput("<input type='checkbox' name='transtext[]' value='".rawurlencode($row['intext'])."' >");
-			addnav("", "runmodule.php?module=translationwizard&op=list&mode=edit&ns=". rawurlencode($row['namespace']));
-			rawoutput("</td><td>");
-			rawoutput(htmlentities($row['intext'],ENT_COMPAT,$coding));
-			rawoutput("</td><td>");
-			rawoutput("<a href='runmodule.php?module=translationwizard&op=list&mode=edit&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']) ."'>". translate_inline("Edit") ."</a>");
-			addnav("", "runmodule.php?module=translationwizard&op=list&mode=edit&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']));
-			rawoutput("<a href='runmodule.php?module=translationwizard&op=list&mode=del&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']) ."'>". translate_inline("Delete") ."</a>");
-			addnav("", "runmodule.php?module=translationwizard&op=list&mode=del&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']));
-			rawoutput("</td></tr>");
-		}
-	}else
-		{
-			rawoutput("<tr><td colspan='2'>". translate_inline("No rows found") ."</td></tr>");
-			if ($namespace<>"")
-				{
-				$namespace="";
-				redirect("runmodule.php?module=translationwizard&op=list&ns=".$namespace); //safety if the rows are empty but the namespace showed up
-				}
-		}
-	rawoutput("</table>");
+                        $checkbox = "<input type='checkbox' name='transtext[]' value='".rawurlencode($row['intext'])."' >";
+                        $actions = "<a href='runmodule.php?module=translationwizard&op=list&mode=edit&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']) ."'>". translate_inline("Edit") ."</a>";
+                        addnav("", "runmodule.php?module=translationwizard&op=list&mode=edit&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']));
+                        $actions .= " <a href='runmodule.php?module=translationwizard&op=list&mode=del&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']) ."'>". translate_inline("Delete") ."</a>";
+                        addnav("", "runmodule.php?module=translationwizard&op=list&mode=del&ns=". rawurlencode($row['namespace']) ."&intext=". rawurlencode($row['intext']));
+                        tw_table_row([
+                            $checkbox,
+                            htmlentities($row['intext'],ENT_COMPAT,$coding),
+                            $actions,
+                        ], $i%2==1);
+                }
+        }else
+                {
+                        tw_table_row([translate_inline("No rows found"), ''], true);
+                        if ($namespace<>"")
+                                {
+                                $namespace="";
+                                redirect("runmodule.php?module=translationwizard&op=list&ns=".$namespace); //safety if the rows are empty but the namespace showed up
+                                }
+                }
+        tw_table_close();
 	//some check/uncheck all
 	$all=translate_inline("Check all");
 	$none=translate_inline("Uncheck all");

--- a/systems/translationwizard/translationwizard/push.php
+++ b/systems/translationwizard/translationwizard/push.php
@@ -124,23 +124,26 @@ default:
 	output_notl("`n`n");
 	output("Select the namespace from your translations you want to push.");
 	output_notl("`n");
-	rawoutput("<table border='0' cellpadding='2' cellspacing='0'>");
-	rawoutput("<tr class='trhead'><td></td><td>". translate_inline("Namespace") ."</td><td>".translate_inline("# of rows")."</td><td>".translate_inline("Actions")."</td></tr>");
-	$i=0;
-	while ($row = db_fetch_assoc($result))
-		{
-		rawoutput("<tr class='".($i%2?"trlight":"trdark")."'><td>");
-		rawoutput("<input type='checkbox' name='pusharray[]' value='".rawurlencode($row['uri'])."' >");
-		rawoutput("</td><td>");
-		rawoutput($row['uri']);
-		rawoutput("</td><td>");
-		rawoutput($row['c']);
-		rawoutput("</td><td>");
-		rawoutput("<a href='runmodule.php?module=translationwizard&op=push&mode=push&pushlanguage=$selectedlanguage&ns=". rawurlencode($row['uri'])."'>". translate_inline("Push")."</a>");
-		addnav("", "runmodule.php?module=translationwizard&op=push&mode=push&pushlanguage=$selectedlanguage&ns=". rawurlencode($row['uri']));
-		rawoutput("</td></tr>");
-		}
-	rawoutput("</table>");
+        tw_table_open([
+            '',
+            translate_inline("Namespace"),
+            translate_inline("# of rows"),
+            translate_inline("Actions"),
+        ]);
+        $i=0;
+        while ($row = db_fetch_assoc($result))
+                {
+                $checkbox = "<input type='checkbox' name='pusharray[]' value='".rawurlencode($row['uri'])."' >";
+                $actions = "<a href='runmodule.php?module=translationwizard&op=push&mode=push&pushlanguage=$selectedlanguage&ns=". rawurlencode($row['uri'])."'>". translate_inline("Push") ."</a>";
+                addnav("", "runmodule.php?module=translationwizard&op=push&mode=push&pushlanguage=$selectedlanguage&ns=". rawurlencode($row['uri']));
+                tw_table_row([
+                    $checkbox,
+                    $row['uri'],
+                    $row['c'],
+                    $actions,
+                ], $i%2==1);
+                }
+        tw_table_close();
 	rawoutput("</form>");
 }
 ?>


### PR DESCRIPTION
## Summary
- implement `tw_table_open`, `tw_table_row` and `tw_table_close`
- refactor list, check and push pages to use helpers

## Testing
- `php -l form_helpers.php`
- `php -l list.php`
- `php -l push.php`
- `php -l check.php`

------
https://chatgpt.com/codex/tasks/task_e_6873fbed071c832989f6479ab66d5ada