### PR TITLE
Escape translation wizard query parameters

### DIFF
--- a/systems/translationwizard/translationwizard/pages/scanmodules.php
+++ b/systems/translationwizard/translationwizard/pages/scanmodules.php
@@ -124,7 +124,12 @@ $sql="SELECT tid,outtext FROM ".db_prefix("translations")." WHERE ";
 $wasthereanuntranslated=0;
 //end
 foreach($ausgabe as $key=>$row) {
-		$result=db_query($sql."intext='".addslashes($row['text'])."' AND language='".$languageschema."' AND uri='".$row['schema']."';");
+                $result=db_query(
+                        $sql
+                        . "intext='" . addslashes($row['text']) . "'"
+                        . " AND language='" . addslashes($languageschema) . "'"
+                        . " AND uri='" . addslashes($row['schema']) . "';"
+                );
 		if (db_num_rows($result)==0) {
 			$alreadytranslated=translate_inline("No");
 			$trans=0;


### PR DESCRIPTION
## Summary
- properly escape variables when querying in scanmodules page

## Testing
- `php -l systems/translationwizard/translationwizard/pages/scanmodules.php`


------
https://chatgpt.com/codex/tasks/task_e_687428788b4483298a1ccbd7e2d7086b