### PR TITLE
Update Translation Wizard to v1.47

### DIFF
--- a/systems/translationwizard/translationwizard.php
+++ b/systems/translationwizard/translationwizard.php
@@ -27,7 +27,7 @@ function translationwizard_getmoduleinfo(): array{
 	//Slightly modified by JT Traub in the original untranslated.php
 	$info = array(
 	    "name"=>"Translation Wizard",
-		"version"=>"1.46",
+		"version"=>"1.47",
 		"author"=>"`2Written by Oliver Brendel, `3based on the untranslated.php by Christian Rutsch`nFilescan by `qEdorian`n",
 		"category"=>"Translations",
 		"download"=>"http://lotgd-downloads.com",

--- a/systems/translationwizard/translationwizard/versions.txt
+++ b/systems/translationwizard/translationwizard/versions.txt
@@ -50,3 +50,4 @@ v1.41 switched to Administrative section + coding scheme now taken from the lotg
 v1.42 added the possibilty to clean up empty namespace rows in the untranslated - idea by Edorian -
 v1.43 added the invalidate for the cached translation quers in 1.1.x and a fix for the scan module regarding addnews
 v.144 serveral smaller bugfixes and adaption to new language settings in 1.1.1 (compatible downwards)
+v1.47 modernization cleanup and strict types enabled for all files


### PR DESCRIPTION
## Summary
- bump version to 1.47 in module info
- document modernization cleanup with strict types enabled

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68742adcd66083298f935902283680c1