### PR TITLE
Fix result variable check in translation wizard

### DIFF
--- a/systems/translationwizard/translationwizard/pages/searchandedit.php
+++ b/systems/translationwizard/translationwizard/pages/searchandedit.php
@@ -200,7 +200,7 @@ switch ($mode)
 				$sql="UPDATE ".db_prefix("translations")." set language='".httppost('language')."', uri='".httppost('uri')."', intext='".httppost('intext')."', outtext='".httppost('outtext')."', author='".httppost('author')."', version='".httppost('version')."' WHERE tid=".httppost('tid').";";
 				$result=db_query($sql);
 				debug($sql);
-				if (!result) redirect('runmodule.php?module=translationwizard&op=searchandedit&error=4&mode=select'); //back to the roots 
+                                if (!$result) redirect('runmodule.php?module=translationwizard&op=searchandedit&error=4&mode=select'); //back to the roots
 				redirect('runmodule.php?module=translationwizard&op=searchandedit&error=5&mode=select'); //back to the roots, no error but success
 
 				break;

--- a/systems/translationwizard/translationwizard/pages/searchandreplace.php
+++ b/systems/translationwizard/translationwizard/pages/searchandreplace.php
@@ -196,7 +196,7 @@ switch ($mode)
 				$sql="UPDATE ".db_prefix("translations")." set language='".httppost('language')."', uri='".httppost('uri')."', intext='".httppost('intext')."', outtext='".httppost('outtext')."', author='".httppost('author')."', version='".httppost('version')."' WHERE tid=".httppost('tid').";";
 				$result=db_query($sql);
 				invalidatedatacache("translations-".$namespace."-".$languageschema);
-				if (!result) redirect('runmodule.php?module=translationwizard&op=searchandreplace&error=4&mode=select'); //back to the roots 
+                                if (!$result) redirect('runmodule.php?module=translationwizard&op=searchandreplace&error=4&mode=select'); //back to the roots
 				redirect('runmodule.php?module=translationwizard&op=searchandreplace&error=5&mode=select'); //back to the roots, no error but success
 
 				break;


### PR DESCRIPTION
## Summary
- fix result check in translation wizard pages

## Testing
- `php -l systems/translationwizard/translationwizard/pages/searchandreplace.php`
- `php -l systems/translationwizard/translationwizard/pages/searchandedit.php`


------
https://chatgpt.com/codex/tasks/task_e_6874d2d48fe883298c7af8aefeefef42