### PR TITLE
Initialize cacheKeys array in WizardService

### DIFF
--- a/systems/translationwizard/translationwizard/WizardService.php
+++ b/systems/translationwizard/translationwizard/WizardService.php
@@ -144,6 +144,7 @@ class WizardService {
         string $version
     ): bool {
         $ok = true;
+        $cacheKeys = [];
         foreach ($inTexts as $key => $text) {
             if ($outTexts[$key] !== '') {
                 $ns = $nameTexts[$key] ?? $namespace;


### PR DESCRIPTION
## Summary
- prevent undefined variable in `WizardService::saveBatchTranslations()`

## Testing
- `php -l systems/translationwizard/translationwizard/WizardService.php`


------
https://chatgpt.com/codex/tasks/task_e_6874d2cef3d8832999802ab961e170e5