### PR TITLE
Fix translationwizard path for deleteuninstalled

### DIFF
--- a/systems/translationwizard/translationwizard.php
+++ b/systems/translationwizard/translationwizard.php
@@ -148,11 +148,11 @@ function translationwizard_dohook(string $hookname, array $args): array{
                 if (get_module_setting("translationdelete")) {
                         if (httpget('op')=="uninstall") {
                                 $get=rawurlencode(serialize(httpallget()));
-                                require_once ("./modules/translationwizard/deleteuninstalled.php");
+                                require_once __DIR__ . '/translationwizard/pages/deleteuninstalled.php';
                         } elseif (httpget('op')=="mass" && httppost("uninstall")) {
                                 $get=rawurlencode(serialize(httpallget()));
                                 $post=rawurlencode(serialize(httpallpost()));
-                                require_once ("./modules/translationwizard/deleteuninstalled.php");
+                                require_once __DIR__ . '/translationwizard/pages/deleteuninstalled.php';
                         }
                 }
                 break;


### PR DESCRIPTION
## Summary
- use `__DIR__` when including the deleteuninstalled page

## Testing
- `php -l systems/translationwizard/translationwizard.php`

------
https://chatgpt.com/codex/tasks/task_e_6874d2c872b083299a34c72bebbab477