### PR TITLE
Update version log path

### DIFF
--- a/systems/translationwizard/translationwizard/pages/showversionlog.php
+++ b/systems/translationwizard/translationwizard/pages/showversionlog.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 require_once("lib/pullurl.php");
-$log=file("modules/translationwizard/versions.txt");
+$log = file(__DIR__ . '/../versions.txt');
 foreach($log as $val) {
 	rawoutput($val);
 	output_notl("`n");


### PR DESCRIPTION
## Summary
- fix relative path for Translation Wizard's version log

## Testing
- `php -l systems/translationwizard/translationwizard/pages/showversionlog.php`

------
https://chatgpt.com/codex/tasks/task_e_6874d2c5f26483299ecd7dcbdfb7be6c