### PR TITLE
Improve TranslationWizard navigation and UI help

### DIFF
--- a/systems/translationwizard/translationwizard/build_nav.php
+++ b/systems/translationwizard/translationwizard/build_nav.php
@@ -1,14 +1,18 @@
 <?php
 
 	addnav(array("`bSwitch to %s view`b",translate_inline($viewsimple?"simple":"advanced")),"runmodule.php?module=translationwizard&op=switchview&from=".rawurlencode("module=translationwizard&op=$op&mode=$mode"));
-	addnav("Operations");
-	addnav("H?Help","runmodule.php?module=translationwizard&op=help");
-	addnav("O?Overview","runmodule.php?module=translationwizard&op=overview");
-	addnav("R?Restart Translator", "runmodule.php?module=translationwizard");
-	addnav("N?Translate by Namespace", "runmodule.php?module=translationwizard&op=list");
-	addnav("C?Check for duplicate entries", "runmodule.php?module=translationwizard&op=check");
-	addnav("F?Fix already translated in table untranslated", "runmodule.php?module=translationwizard&op=fix");
-	addnav("k?Check for known translations","runmodule.php?module=translationwizard&op=known");
+       addnav("Information");
+       addnav("H?Help","runmodule.php?module=translationwizard&op=help");
+       addnav("O?Overview","runmodule.php?module=translationwizard&op=overview");
+
+       addnav("Translation Tasks");
+       addnav("R?Restart Translator", "runmodule.php?module=translationwizard");
+       addnav("N?Translate by Namespace", "runmodule.php?module=translationwizard&op=list");
+       addnav("F?Fix already translated", "runmodule.php?module=translationwizard&op=fix");
+       addnav("C?Check for duplicate entries", "runmodule.php?module=translationwizard&op=check");
+       addnav("k?Check for known translations","runmodule.php?module=translationwizard&op=known");
+
+       addnav("Database Tools");
 	if (get_module_setting('restricted')&& $viewsimple)	{
 		if (get_module_pref('allowed'))	{
 				addnav(array("Search+Edit the translations table %s",""),"runmodule.php?module=translationwizard&op=searchandedit");
@@ -36,7 +40,7 @@
 		addnav("Check for known translations","runmodule.php?module=translationwizard&op=known&central=1");
 		addnav("Truncate pulled translations table","runmodule.php?module=translationwizard&op=truncate&central=1");
 	}
-	addnav("Your current scheme:");
+	addnav("Current Scheme");
 	if ($languageschema<>'') {
 			addnav($languageschema,"!!!addraw!!!",true);
 		} else {
@@ -44,7 +48,7 @@
 			$languageschema="en"; //in case some dummy just wants to click ahead he gets English as a default
 		}
 	addnav("Change current scheme","runmodule.php?module=translationwizard&op=changescheme");
-	addnav("Miscellaneous");
+	addnav("Settings");
 	addnav("Show Versionlog","runmodule.php?module=translationwizard&op=showversionlog");
 	if ($viewsimple) addnav("Scan Modules","runmodule.php?module=translationwizard&op=scanmodules");
 	

--- a/systems/translationwizard/translationwizard/default.php
+++ b/systems/translationwizard/translationwizard/default.php
@@ -1,4 +1,23 @@
 <?php
+output("`^Welcome to the Translation Wizard.`0");
+output_notl("`n");
+output("This tool stores untranslated lines in a separate table and keeps your finished translations in the main translations table. Use the links on the left to maintain these lists and fetch data from the central repository.");
+output_notl("`n`n");
+output("`bNavigation overview:`b");
+output_notl("`n");
+output("`bOverview:`b summary of your translation tables.");
+output_notl("`n");
+output("`bRestart Translator:`b work on random untranslated strings.");
+output_notl("`n");
+output("`bTranslate by Namespace:`b translate texts from a specific module.");
+output_notl("`n");
+output("`bFix already translated:`b remove lines already translated.");
+output_notl("`n");
+output("`bCheck for duplicate entries:`b find duplicate rows in your translations.");
+output_notl("`n");
+output("`bCheck for known translations:`b see if you already translated the text elsewhere.");
+output_notl("`n`n");
+
 $sql = "SELECT count(*) AS count FROM " . db_prefix("untranslated");
 $count = db_fetch_assoc(db_query($sql));
 if ($count['count'] > 0) {


### PR DESCRIPTION
## Summary
- restructure Translation Wizard navigation into clear groups
- add explanation of the wizard and navigation links to the start page

## Testing
- `php -l systems/translationwizard/translationwizard/build_nav.php`
- `php -l systems/translationwizard/translationwizard/default.php`


------
https://chatgpt.com/codex/tasks/task_e_6874e2c941788329a6fe93b2c1c99d62