### PR TITLE
Add strict types to Specialty System

### DIFF
--- a/systems/specialtysystem/specialtysystem.php
+++ b/systems/specialtysystem/specialtysystem.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_getmoduleinfo(){
+/**
+ * Module information for the core system.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty Core System",
 		"author" => "`2Oliver Brendel",
@@ -21,7 +27,12 @@ function specialtysystem_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_install(){
+/**
+ * Install the core module.
+ *
+ * @return bool
+ */
+function specialtysystem_install(): bool {
 	module_addhook("newday-intercept");
 
 	//legacy support
@@ -60,7 +71,12 @@ function specialtysystem_install(){
 	return true;
 }
 
-function specialtysystem_uninstall(){
+/**
+ * Uninstall the core module.
+ *
+ * @return bool
+ */
+function specialtysystem_uninstall(): bool {
 	// Delete us and let the newday do what it wants to ... let them select a new specialty
 	$sql="UPDATE ".db_prefix('accounts')." SET specialty='' WHERE specialty='SS'";
 	db_query($sql);
@@ -70,7 +86,14 @@ function specialtysystem_uninstall(){
 	return true;
 }
 
-function specialtysystem_showfightnav($script,$force=false) {
+/**
+ * Output fight navigation for all specialties.
+ *
+ * @param string $script
+ * @param bool $force
+ * @return void
+ */
+function specialtysystem_showfightnav(string $script, bool $force = false): void {
 	global $session;
 	$check=unserialize(stripslashes(get_module_pref("cache","specialtysystem")));
 	if (isset($check['system']) && $check['system']=='specialtysystem' && !$force) {
@@ -126,7 +149,14 @@ function specialtysystem_showfightnav($script,$force=false) {
 	return;
 }
 
-function specialtysystem_dohook($hookname,$args){
+/**
+ * Handle LoTGD hooks for the core system.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_dohook(string $hookname, array $args): array {
 	global $session,$resline;
 	//resline is a hack to transfer the &ressurrection=0/1 ... I leave it in here ... for now.
 
@@ -332,7 +362,10 @@ function specialtysystem_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_run(){
+/**
+ * Module runtime operations.
+ */
+function specialtysystem_run(): void {
 	$op=httpget('op');
 	switch ($op) {
 		case "refresh":

--- a/systems/specialtysystem/specialtysystem/datafunctions.php
+++ b/systems/specialtysystem/specialtysystem/datafunctions.php
@@ -1,5 +1,12 @@
 <?php
-function specialtysystem_set($array,$user=false) {
+declare(strict_types=1);
+/**
+ * Store specialty data for a user.
+ *
+ * @param array $array Key/value pairs of module data
+ * @param int|null $user Optional user id, null for current user
+ */
+function specialtysystem_set(array $array, ?int $user = null): void {
 	$get=unserialize(stripslashes(get_module_pref("data","specialtysystem",$user)));
 	if (!is_array($get))$get=array();
 	foreach ($array as $modulename=>$data) {
@@ -11,17 +18,26 @@ function specialtysystem_set($array,$user=false) {
 		}
 	}
 	set_module_pref("data",addslashes(serialize($get)),"specialtysystem",$user);
-	return;
+        return;
 }
 
-function specialtysystem_newday() {
+/**
+ * Reset specialty data on new day.
+ */
+function specialtysystem_newday(): void {
 	global $session;
 	set_module_pref("uses",0,"specialtysystem");
 	$session['user']['specialmisc']='';
-	return;
+        return;
 }
 
-function specialtysystem_getspecs($modulename=false) {
+/**
+ * Retrieve registered specialties.
+ *
+ * @param string|null $modulename Specific module name or null for all
+ * @return array<string, mixed>
+ */
+function specialtysystem_getspecs(?string $modulename = null): array {
 	if (($spec=datacache("specialtygetspecs",3600))!=false) {
 		if ($modulename==false) {
 				return unserialize(stripslashes($spec));
@@ -38,10 +54,17 @@ function specialtysystem_getspecs($modulename=false) {
 	while ($row=db_fetch_assoc($result))
 		$spec[$row['modulename']]=$row;
 	if ($modulename==false) updatedatacache("specialtygetspecs",addslashes(serialize($spec)));
-	return $spec;
+        return $spec;
 }
 
-function specialtysystem_increment($modulename,$value=1) {
+/**
+ * Increase skill points for a specialty.
+ *
+ * @param string $modulename Module identifier
+ * @param int $value Amount to increment
+ * @return int New skill point total
+ */
+function specialtysystem_increment(string $modulename, int $value = 1): int {
 	$get=unserialize(stripslashes(get_module_pref("data","specialtysystem")));
 	if (array_key_exists($modulename,$get)) {
 		$exist=$get[$modulename];
@@ -52,15 +75,22 @@ function specialtysystem_increment($modulename,$value=1) {
 		$get[$modulename]=$exist;
 	}
 	set_module_pref("data",addslashes(serialize($get)),"specialtysystem");
-	return $exist['skillpoints'];
+        return $exist['skillpoints'];
 }
 
-function specialtysystem_get($modulename=false,$user=false){
+/**
+ * Get stored specialty data for a user.
+ *
+ * @param string|null $modulename Module name or null for all
+ * @param int|null $user User id or null for current user
+ * @return array|null
+ */
+function specialtysystem_get(?string $modulename = null, ?int $user = null): ?array {
 	$get=unserialize(stripslashes(get_module_pref("data","specialtysystem",$user)));
 	if ($modulename==false) return $get;
 	if (isset($get[$modulename]) && $get[$modulename]!='')
-		return $get[$modulename];
-		else
-		return false;
+                return $get[$modulename];
+                else
+                return null;
 }
 ?>

--- a/systems/specialtysystem/specialtysystem/functions.php
+++ b/systems/specialtysystem/specialtysystem/functions.php
@@ -1,7 +1,14 @@
 <?php
+declare(strict_types=1);
 //functions for the specsystem
 
-function specialtysystem_availableuses($modulename=false) {
+/**
+ * Calculate usable points for a specialty.
+ *
+ * @param string|null $modulename Target module or null for overall points
+ * @return int
+ */
+function specialtysystem_availableuses(?string $modulename = null): int {
 	$upper=specialtysystem_getskillpoints();
 	$lower=specialtysystem_getskillpoints($modulename);
 	$uses=specialtysystem_getuses();
@@ -14,7 +21,13 @@ function specialtysystem_availableuses($modulename=false) {
 	return $av;
 }
 
-function specialtysystem_getskillpoints($modulename=false) {
+/**
+ * Fetch accumulated skill points.
+ *
+ * @param string|null $modulename Module name or null for all
+ * @return int
+ */
+function specialtysystem_getskillpoints(?string $modulename = null): int {
 	require_once("modules/specialtysystem/datafunctions.php");
 	$ret=0;
 	if ($modulename==false) {
@@ -35,17 +48,33 @@ function specialtysystem_getskillpoints($modulename=false) {
 	return $ret;
 }
 
-function specialtysystem_getuses() {
+/**
+ * Get number of used points for current day.
+ *
+ * @return int
+ */
+function specialtysystem_getuses(): int {
 	$data2=get_module_pref("uses","specialtysystem");
 	return $data2;
 }
 
-function specialtysystem_setuses($value) {
+/**
+ * Persist used points value.
+ *
+ * @param int $value
+ */
+function specialtysystem_setuses(int $value): void {
 	set_module_pref("uses",$value,"specialtysystem");
 	return;
 }
 
-function specialtysystem_incrementuses($modulename,$value) {
+/**
+ * Increase uses for a specialty.
+ *
+ * @param string $modulename
+ * @param int $value
+ */
+function specialtysystem_incrementuses(string $modulename, int $value): void {
 	require_once("modules/specialtysystem/datafunctions.php");
 	$uses=get_module_pref("uses","specialtysystem");
 	if ($uses!='') $uses+=(int)$value;
@@ -54,7 +83,14 @@ function specialtysystem_incrementuses($modulename,$value) {
 	return;
 }
 
-function specialtysystem_addfightheadline($name,$uses=false,$max=false) {
+/**
+ * Add a section headline to the fight navigation collector.
+ *
+ * @param string $name
+ * @param int|null $uses
+ * @param int|null $max
+ */
+function specialtysystem_addfightheadline(string $name, ?int $uses = null, ?int $max = null): void {
 	global $specialtycollector;
 	if (!is_array($specialtycollector)) $specialtycollector=array();
 	if ($uses!=false) {
@@ -66,7 +102,14 @@ function specialtysystem_addfightheadline($name,$uses=false,$max=false) {
 	return;
 }
 
-function specialtysystem_addfightnav($name,$link=false,$uses=false) {
+/**
+ * Append an entry to the fight navigation collector.
+ *
+ * @param string $name
+ * @param string|null $link
+ * @param int|null $uses
+ */
+function specialtysystem_addfightnav(string $name, ?string $link = null, ?int $uses = null): void {
 	global $specialtycollector;
 	if (is_array('name')) {
 		$name=sprintf_translate($name);
@@ -84,7 +127,12 @@ function specialtysystem_addfightnav($name,$link=false,$uses=false) {
 	return;
 }
 
-function specialtysystem_getfightnav() {
+/**
+ * Return and reset the fight navigation collector.
+ *
+ * @return array
+ */
+function specialtysystem_getfightnav(): array {
 	global $specialtycollector;
 	$return=$specialtycollector;
 	$specialtycollector=false;

--- a/systems/specialtysystem/specialtysystem/register.php
+++ b/systems/specialtysystem/specialtysystem/register.php
@@ -1,6 +1,10 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_register() {
+/**
+ * Register all specialty modules in the database.
+ */
+function specialtysystem_register(): void {
 	$args=modulehook("specialtysystem-register",array());
 	invalidatedatacache("specialtygetspecs");
 	debug($args);
@@ -19,10 +23,10 @@ function specialtysystem_register() {
 
 		$insert[]=" ('".addslashes($data['spec_name'])."','{$data['spec_colour']}','".addslashes($data['spec_shortdescription'])."','".addslashes($data['spec_longdescription'])."','{$data['modulename']}','{$data['fightnav_active']}','{$data['newday_active']}','{$data['dragonkill_active']}','{$data['dragonkill_minimum_requirement']}','".addslashes(serialize($data['stat_requirements']))."','".addslashes(serialize($data['race_requirements']))."','{$data['noaddskillpoints']}','{$data['basic_uses']}')";
 	}
-	if ($insert==array()) return;
-	debug($insert);
-	$sql.=implode(",",$insert);
-	return db_query($sql);
+        if ($insert==array()) return;
+        debug($insert);
+        $sql.=implode(",",$insert);
+        db_query($sql);
 	/*usage:
 	for first registering
 

--- a/systems/specialtysystem/specialtysystem/uninstall.php
+++ b/systems/specialtysystem/specialtysystem/uninstall.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_uninstall($modulename) { // the array itself will stay with the skillpoints... so they can't use that skill in battle, but still have the chakra points.
+/**
+ * Remove a specialty module from the registry.
+ *
+ * @param string $modulename
+ */
+function specialtysystem_uninstall(string $modulename): void { // the array itself will stay with the skillpoints... so they can't use that skill in battle, but still have the chakra points.
 	$sql="DELETE FROM ".db_prefix('specialtysystem')." WHERE modulename='$modulename'";
 	db_query($sql);
 }

--- a/systems/specialtysystem/specialtysystem_basic.php
+++ b/systems/specialtysystem/specialtysystem_basic.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_basic_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_basic_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Basic Techniques",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_basic_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_basic_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_basic_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_basic_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_basic_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_basic");
 	return true;
 }
 
-function specialtysystem_basic_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_basic_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_basic");
@@ -41,7 +62,12 @@ function specialtysystem_basic_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_basic_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_basic_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$u=&$session['user'];
@@ -111,7 +137,14 @@ function specialtysystem_basic_apply($skillname){
 	return;
 }
 
-function specialtysystem_basic_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_basic_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -131,6 +164,9 @@ function specialtysystem_basic_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_basic_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_basic_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_earth.php
+++ b/systems/specialtysystem/specialtysystem_earth.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_earth_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_earth_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Earth",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_earth_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_earth_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_earth_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_earth_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_earth_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_earth");
 	return true;
 }
 
-function specialtysystem_earth_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_earth_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_earth");
@@ -57,7 +78,12 @@ function specialtysystem_earth_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_earth_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_earth_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -160,7 +186,14 @@ function specialtysystem_earth_apply($skillname){
 	return;
 }
 
-function specialtysystem_earth_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_earth_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -183,6 +216,9 @@ function specialtysystem_earth_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_earth_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_earth_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_fire.php
+++ b/systems/specialtysystem/specialtysystem_fire.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_fire_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_fire_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Fire",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_fire_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_fire_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_fire_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_fire_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_fire_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_fire");
 	return true;
 }
 
-function specialtysystem_fire_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_fire_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_fire");
@@ -57,7 +78,12 @@ function specialtysystem_fire_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_fire_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_fire_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -162,7 +188,14 @@ function specialtysystem_fire_apply($skillname){
 	return;
 }
 
-function specialtysystem_fire_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_fire_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -186,6 +219,9 @@ function specialtysystem_fire_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_fire_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_fire_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_genjutsu.php
+++ b/systems/specialtysystem/specialtysystem_genjutsu.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_genjutsu_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_genjutsu_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Genjutsu",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_genjutsu_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_genjutsu_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_genjutsu_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_genjutsu_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_genjutsu_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_genjutsu");
 	return true;
 }
 
-function specialtysystem_genjutsu_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_genjutsu_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_genjutsu");
@@ -57,7 +78,12 @@ function specialtysystem_genjutsu_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_genjutsu_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_genjutsu_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -148,7 +174,14 @@ function specialtysystem_genjutsu_apply($skillname){
 	return;
 }
 
-function specialtysystem_genjutsu_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_genjutsu_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -167,6 +200,9 @@ function specialtysystem_genjutsu_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_genjutsu_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_genjutsu_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_ice.php
+++ b/systems/specialtysystem/specialtysystem_ice.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_ice_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_ice_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Ice",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_ice_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_ice_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_ice_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_ice_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_ice_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_ice");
 	return true;
 }
 
-function specialtysystem_ice_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_ice_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_ice");
@@ -57,7 +78,12 @@ function specialtysystem_ice_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_ice_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_ice_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -160,7 +186,14 @@ function specialtysystem_ice_apply($skillname){
 	return;
 }
 
-function specialtysystem_ice_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_ice_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -184,6 +217,9 @@ function specialtysystem_ice_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_ice_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_ice_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_lightning.php
+++ b/systems/specialtysystem/specialtysystem_lightning.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_lightning_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_lightning_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Lightning",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_lightning_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_lightning_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_lightning_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_lightning_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_lightning_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_lightning");
 	return true;
 }
 
-function specialtysystem_lightning_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_lightning_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_lightning");
@@ -60,7 +81,12 @@ function specialtysystem_lightning_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_lightning_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_lightning_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -176,7 +202,14 @@ function specialtysystem_lightning_apply($skillname){
 	return;
 }
 
-function specialtysystem_lightning_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_lightning_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -195,6 +228,9 @@ function specialtysystem_lightning_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_lightning_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_lightning_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_medical.php
+++ b/systems/specialtysystem/specialtysystem_medical.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_medical_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_medical_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Medical",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_medical_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_medical_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_medical_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_medical_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_medical_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_medical");
 	return true;
 }
 
-function specialtysystem_medical_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_medical_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_medical");
@@ -60,7 +81,12 @@ function specialtysystem_medical_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_medical_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_medical_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -168,7 +194,14 @@ function specialtysystem_medical_apply($skillname){
 	return;
 }
 
-function specialtysystem_medical_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_medical_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -191,6 +224,9 @@ function specialtysystem_medical_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_medical_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_medical_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_sand.php
+++ b/systems/specialtysystem/specialtysystem_sand.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_sand_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_sand_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Sand",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_sand_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_sand_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_sand_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_sand_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_sand_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_sand");
 	return true;
 }
 
-function specialtysystem_sand_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_sand_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_sand");
@@ -57,7 +78,12 @@ function specialtysystem_sand_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_sand_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_sand_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -157,7 +183,14 @@ function specialtysystem_sand_apply($skillname){
 	return;
 }
 
-function specialtysystem_sand_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_sand_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -179,6 +212,9 @@ function specialtysystem_sand_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_sand_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_sand_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_water.php
+++ b/systems/specialtysystem/specialtysystem_water.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_water_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_water_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Water",
 		"author" => "`2Oliver Brendel`0",
@@ -14,18 +20,33 @@ function specialtysystem_water_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_water_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_water_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_water_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_water_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_water");
 	return true;
 }
 
-function specialtysystem_water_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_water_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_water");
@@ -60,7 +81,12 @@ function specialtysystem_water_fightnav(){
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_water_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_water_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -178,7 +204,14 @@ function specialtysystem_water_apply($skillname){
 	return;
 }
 
-function specialtysystem_water_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_water_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -200,6 +233,9 @@ function specialtysystem_water_dohook($hookname,$args){
 	return $args;
 }
 
-function specialtysystem_water_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_water_run(): void {
 }
 ?>

--- a/systems/specialtysystem/specialtysystem_wind.php
+++ b/systems/specialtysystem/specialtysystem_wind.php
@@ -1,6 +1,12 @@
 <?php
+declare(strict_types=1);
 
-function specialtysystem_wind_getmoduleinfo(){
+/**
+ * Module information.
+ *
+ * @return array<string, mixed>
+ */
+function specialtysystem_wind_getmoduleinfo(): array {
 	$info = array(
 		"name" => "Specialty System - Wind",
 		"author" => "`2Oliver`0",
@@ -14,18 +20,33 @@ function specialtysystem_wind_getmoduleinfo(){
 	return $info;
 }
 
-function specialtysystem_wind_install(){
+/**
+ * Install the module.
+ *
+ * @return bool
+ */
+function specialtysystem_wind_install(): bool {
 	module_addhook("specialtysystem-register");
 	return true;
 }
 
-function specialtysystem_wind_uninstall(){
+/**
+ * Uninstall the module.
+ *
+ * @return bool
+ */
+function specialtysystem_wind_uninstall(): bool {
 	require_once("modules/specialtysystem/uninstall.php");
 	specialtysystem_uninstall("specialtysystem_wind");
 	return true;
 }
 
-function specialtysystem_wind_fightnav(){
+/**
+ * Build fight navigation entries.
+ *
+ * @return array
+ */
+function specialtysystem_wind_fightnav(): array {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	$uses=specialtysystem_availableuses("specialtysystem_wind");
@@ -58,7 +79,12 @@ $uses,specialtysystem_getskillpoints("specialtysystem_wind"));
 	return specialtysystem_getfightnav();
 }
 
-function specialtysystem_wind_apply($skillname){
+/**
+ * Apply a selected specialty skill.
+ *
+ * @param string $skillname
+ */
+function specialtysystem_wind_apply(string $skillname): void {
 	global $session;
 	require_once("modules/specialtysystem/functions.php");
 	switch($skillname){
@@ -166,7 +192,14 @@ and shoots a large ball of compressed air and chakra at {badguy}!",
 	return;
 }
 
-function specialtysystem_wind_dohook($hookname,$args){
+/**
+ * Handle module hooks.
+ *
+ * @param string $hookname
+ * @param array $args
+ * @return array
+ */
+function specialtysystem_wind_dohook(string $hookname, array $args): array {
 	switch ($hookname) {
 	case "specialtysystem-register":
 		$args[]=array(
@@ -192,7 +225,10 @@ in your path away.',
 	return $args;
 }
 
-function specialtysystem_wind_run(){
+/**
+ * Module runtime.
+ */
+function specialtysystem_wind_run(): void {
 }
 ?>
 


### PR DESCRIPTION
## Summary
- enable strict typing in specialty system modules
- add typed parameters and return types
- document all functions with docblocks

## Testing
- `php -l systems/specialtysystem/specialtysystem_wind.php`
- `php -l systems/specialtysystem/specialtysystem/functions.php`
- `php -l systems/specialtysystem/specialtysystem/datafunctions.php`
- `php -l systems/specialtysystem/specialtysystem/register.php`
- `php -l systems/specialtysystem/specialtysystem/uninstall.php`
- `php -l systems/specialtysystem/specialtysystem_water.php`
- `php -l systems/specialtysystem/specialtysystem_sand.php`
- `php -l systems/specialtysystem/specialtysystem_medical.php`
- `php -l systems/specialtysystem/specialtysystem.php`
- `php -l systems/specialtysystem/specialtysystem_fire.php`
- `php -l systems/specialtysystem/specialtysystem_lightning.php`
- `php -l systems/specialtysystem/specialtysystem_ice.php`
- `php -l systems/specialtysystem/specialtysystem_basic.php`
- `php -l systems/specialtysystem/specialtysystem_genjutsu.php`
- `php -l systems/specialtysystem/specialtysystem_earth.php`


------
https://chatgpt.com/codex/tasks/task_e_68767274371c832984104e297552b20d