### PR TITLE
Document findloot inventory module

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Below is a short description for every module. Some modules rely on others; depe
 
 ### inventory
 - **inventory** - the entire updated item system by XChrisX for run with +nb core
+- **findloot** – hooks `battle-victory` to roll for loot items via the inventory system (`items/findloot.php`).
 
 ### Lodge
 - **lodgedkpointreset** – reset spent lodge points for a dragon kill.


### PR DESCRIPTION
## Summary
- document the findloot inventory module in the README
- note that it hooks `battle-victory` to roll for loot items via `items/findloot.php`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9cf3cb4188329a5cecb749e322518