### PR TITLE
Document Lodge color table module

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Below is a short description for every module. Some modules rely on others; depe
 - **inventory** - the entire updated item system by XChrisX for run with +nb core
 
 ### Lodge
+- **lodge_colortable** – adds a Lodge navigation link displaying the LoTGD color table and a sample text input (`lodge/lodge_colortable.php`).
 - **lodgedkpointreset** – reset spent lodge points for a dragon kill.
 - **lodgenonexpiration** – purchase non‑expiration account upgrade.
 - **namechange** – allow players to change character name.


### PR DESCRIPTION
## Summary
- list the new `lodge_colortable` module in the Lodge section of the README
- describe that it adds a Lodge navigation link showing the LoTGD color table and a sample text input

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9cf3d37fc83298878ebb106f1075c