### PR TITLE
Document elemental specialty modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Below is a short description for every module. Some modules rely on others; depe
 - **specialtysystem_ice** – ice specialties (requires `specialtysystem`).
 - **specialtysystem_lightning** – lightning specialties (requires `specialtysystem`).
 - **specialtysystem_medical** – medical specialties (requires `specialtysystem`).
+- **specialtysystem_sand** – registers sand elemental jutsu combat options for the specialty system (requires `specialtysystem`).
+- **specialtysystem_water** – registers water elemental jutsu combat options for the specialty system (requires `specialtysystem`).
+- **specialtysystem_wind** – registers wind elemental jutsu combat options for the specialty system (requires `specialtysystem`).
 - **translationwizard** – translation management wizard for text output.
 
 ### Village modules


### PR DESCRIPTION
## Summary
- add README entries for the sand, water, and wind specialty specialties

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9cf4003bc8329813748de20550c89